### PR TITLE
Simplifying CommandDialog and relying on CommandForm to the heavy lifting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,9 @@
     "primeicons",
     "primereact",
     "trackpad",
-    "trackpads"
+    "trackpads",
+    "tsyringe",
+    "usehooks"
   ],
   "typescript.tsdk": ".yarn/sdks/typescript/lib",
   "search.exclude": {

--- a/Source/CommandDialog/CommandDialog.stories.tsx
+++ b/Source/CommandDialog/CommandDialog.stories.tsx
@@ -4,7 +4,7 @@
 import React, { useState } from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { CommandDialog } from './CommandDialog';
-import { Command, CommandValidator } from '@cratis/arc/commands';
+import { Command, CommandResult, CommandValidator } from '@cratis/arc/commands';
 import { PropertyDescriptor } from '@cratis/arc/reflection';
 import { InputTextField, NumberField, TextAreaField } from '../CommandForm/fields';
 import '@cratis/arc/validation';
@@ -27,6 +27,41 @@ class UpdateUserCommandValidator extends CommandValidator {
 }
 
 class UpdateUserCommand extends Command<object> {
+    readonly route: string = '/api/users/update';
+    readonly validation: CommandValidator = new UpdateUserCommandValidator();
+    readonly propertyDescriptors: PropertyDescriptor[] = [
+        new PropertyDescriptor('name', String),
+        new PropertyDescriptor('email', String),
+        new PropertyDescriptor('age', Number),
+    ];
+
+    name = '';
+    email = '';
+    age = 0;
+
+    constructor() {
+        super(Object, false);
+    }
+
+    get requestParameters(): string[] {
+        return [];
+    }
+
+    get properties(): string[] {
+        return ['name', 'email', 'age'];
+    }
+
+    override async validate(): Promise<CommandResult<object>> {
+        const errors = this.validation?.validate(this) ?? [];
+        if (errors.length > 0) {
+            return CommandResult.validationFailed(errors);
+        }
+        return CommandResult.empty;
+    }
+}
+
+/** Variant that keeps the original server-calling validate() for the WithServerValidation story. */
+class UpdateUserCommandWithServer extends Command<object> {
     readonly route: string = '/api/users/update';
     readonly validation: CommandValidator = new UpdateUserCommandValidator();
     readonly propertyDescriptors: PropertyDescriptor[] = [
@@ -93,20 +128,16 @@ const DialogWrapper = () => {
                 header="Update User Information (with Validation)"
                 confirmLabel="Save"
                 cancelLabel="Cancel"
+                autoServerValidate={false}
                 onConfirm={async (commandResult) => {
                     setResult(JSON.stringify(commandResult));
                     setVisible(false);
                 }}
                 onCancel={() => setVisible(false)}
-                onFieldChange={async (command) => {
-                    // Progressive validation - validate as fields change
-                    const validationResult = await command.validate();
-                    
-                    if (!validationResult.isValid) {
-                        setValidationErrors(validationResult.validationResults.map(v => v.message));
-                    } else {
-                        setValidationErrors([]);
-                    }
+                onFieldChange={(command) => {
+                    // Client-side only validation - validate as fields change
+                    const errors = command.validation?.validate(command) ?? [];
+                    setValidationErrors(errors.map(v => v.message));
                 }}
             >
                 <InputTextField value={(c: UpdateUserCommand) => c.name} title="Name" placeholder="Enter name (min 2 chars)" />
@@ -117,8 +148,77 @@ const DialogWrapper = () => {
     );
 };
 
+const ServerValidationWrapper = () => {
+    const [visible, setVisible] = useState(true);
+    const [result, setResult] = useState<string>('');
+    const [validationErrors, setValidationErrors] = useState<string[]>([]);
+
+    return (
+        <div className="storybook-wrapper">
+            <button
+                className="p-button p-component mb-3"
+                onClick={() => {
+                    setVisible(true);
+                    setValidationErrors([]);
+                    setResult('');
+                }}
+            >
+                Open Dialog
+            </button>
+
+            {validationErrors.length > 0 && (
+                <div className="p-3 mt-3 bg-red-100 border-round">
+                    <strong>Validation Errors:</strong>
+                    <ul className="mt-2 mb-0">
+                        {validationErrors.map((error, index) => (
+                            <li key={index}>{error}</li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+
+            {result && (
+                <div className="p-3 mt-3 bg-green-100 border-round">
+                    <strong>Command executed:</strong> {result}
+                </div>
+            )}
+
+            <CommandDialog<UpdateUserCommandWithServer>
+                command={UpdateUserCommandWithServer}
+                visible={visible}
+                header="Update User Information (with Server Validation)"
+                confirmLabel="Save"
+                cancelLabel="Cancel"
+                onConfirm={async (commandResult) => {
+                    setResult(JSON.stringify(commandResult));
+                    setVisible(false);
+                }}
+                onCancel={() => setVisible(false)}
+                onFieldChange={async (command) => {
+                    // Progressive validation - validate as fields change
+                    const validationResult = await command.validate();
+
+                    if (!validationResult.isValid) {
+                        setValidationErrors(validationResult.validationResults.map(v => v.message));
+                    } else {
+                        setValidationErrors([]);
+                    }
+                }}
+            >
+                <InputTextField value={(c: UpdateUserCommandWithServer) => c.name} title="Name" placeholder="Enter name (min 2 chars)" />
+                <InputTextField value={(c: UpdateUserCommandWithServer) => c.email} title="Email" placeholder="Enter email" type="email" />
+                <NumberField value={(c: UpdateUserCommandWithServer) => c.age} title="Age" placeholder="Enter age (18-120)" />
+            </CommandDialog>
+        </div>
+    );
+};
+
 export const Default: Story = {
     render: () => <DialogWrapper />,
+};
+
+export const WithServerValidation: Story = {
+    render: () => <ServerValidationWrapper />,
 };
 
 const EditUserWrapper = () => {
@@ -165,6 +265,7 @@ const EditUserWrapper = () => {
                 header={`Edit User: ${selectedUser?.name ?? ''}`}
                 confirmLabel="Save"
                 cancelLabel="Cancel"
+                autoServerValidate={false}
                 onConfirm={async () => {
                     setResult(`User "${selectedUser?.name}" updated successfully`);
                     setVisible(false);
@@ -211,6 +312,7 @@ const CustomValidationWrapper = () => {
                 header="Add User (with Custom Validation)"
                 confirmLabel="Save"
                 cancelLabel="Cancel"
+                autoServerValidate={false}
                 onConfirm={async () => {
                     setResult('User added successfully');
                     setVisible(false);
@@ -262,6 +364,7 @@ const ValidationOnBlurWrapper = () => {
                 confirmLabel="Save"
                 cancelLabel="Cancel"
                 validateOn="blur"
+                autoServerValidate={false}
                 onConfirm={async () => setVisible(false)}
                 onCancel={() => setVisible(false)}
             >
@@ -292,6 +395,7 @@ const ValidationOnChangeWrapper = () => {
                 confirmLabel="Save"
                 cancelLabel="Cancel"
                 validateOn="change"
+                autoServerValidate={false}
                 onConfirm={async () => setVisible(false)}
                 onCancel={() => setVisible(false)}
             >
@@ -322,6 +426,7 @@ const ValidateOnInitWrapper = () => {
                 confirmLabel="Save"
                 cancelLabel="Cancel"
                 validateOnInit={true}
+                autoServerValidate={false}
                 initialValues={{ name: 'A', email: 'invalid', age: 10 }}
                 onConfirm={async () => setVisible(false)}
                 onCancel={() => setVisible(false)}
@@ -354,6 +459,7 @@ const ValidateAllFieldsWrapper = () => {
                 cancelLabel="Cancel"
                 validateOn="blur"
                 validateAllFieldsOnChange={true}
+                autoServerValidate={false}
                 onConfirm={async () => setVisible(false)}
                 onCancel={() => setVisible(false)}
             >
@@ -392,6 +498,7 @@ const BeforeExecuteWrapper = () => {
                 header="Before Execute Callback"
                 confirmLabel="Save"
                 cancelLabel="Cancel"
+                autoServerValidate={false}
                 initialValues={{ name: '', email: '', age: 18 }}
                 onBeforeExecute={(command) => {
                     command.name = command.name.trim().replace(/\s+/g, ' ');
@@ -430,6 +537,7 @@ const WithIconsWrapper = () => {
                 header="Fields with Icons"
                 confirmLabel="Save"
                 cancelLabel="Cancel"
+                autoServerValidate={false}
                 onConfirm={async () => setVisible(false)}
                 onCancel={() => setVisible(false)}
             >
@@ -500,6 +608,14 @@ class UpdateProfileCommand extends Command<object> {
     get properties(): string[] {
         return ['firstName', 'lastName', 'email', 'phone', 'bio'];
     }
+
+    override async validate(): Promise<CommandResult<object>> {
+        const errors = this.validation?.validate(this) ?? [];
+        if (errors.length > 0) {
+            return CommandResult.validationFailed(errors);
+        }
+        return CommandResult.empty;
+    }
 }
 
 const MultiColumnWrapper = () => {
@@ -517,6 +633,7 @@ const MultiColumnWrapper = () => {
                 confirmLabel="Save"
                 cancelLabel="Cancel"
                 width="70vw"
+                autoServerValidate={false}
                 onConfirm={async () => setVisible(false)}
                 onCancel={() => setVisible(false)}
             >
@@ -554,6 +671,7 @@ const MixedChildrenWrapper = () => {
                 header="Edit Profile (Mixed Children)"
                 confirmLabel="Save"
                 cancelLabel="Cancel"
+                autoServerValidate={false}
                 onConfirm={async () => setVisible(false)}
                 onCancel={() => setVisible(false)}
             >

--- a/Source/CommandDialog/CommandDialog.tsx
+++ b/Source/CommandDialog/CommandDialog.tsx
@@ -2,79 +2,29 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { ICommandResult } from '@cratis/arc/commands';
-import { Constructor } from '@cratis/fundamentals';
 import { DialogButtons } from '@cratis/arc.react/dialogs';
 import { Dialog } from '../Dialogs/Dialog';
-import React, { createContext, useContext } from 'react';
-import { 
-    CommandForm, 
+import React from 'react';
+import {
+    CommandForm,
     CommandFormFieldWrapper,
-    useCommandFormContext, 
-    useCommandInstance
+    useCommandFormContext,
+    useCommandInstance,
+    type CommandFormProps
 } from '@cratis/arc.react/commands';
 
-type CommandFormProps = React.ComponentProps<typeof CommandForm>;
-
-// Local type definitions
-export type BeforeExecuteCallback<TCommand> = (values: TCommand) => TCommand;
-
-export type FieldValidator<TCommand> = (command: TCommand, fieldName: string, oldValue: unknown, newValue: unknown) => string | undefined;
-export type FieldChangeCallback<TCommand> = (command: TCommand, fieldName: string, oldValue: unknown, newValue: unknown) => void;
-
-export interface CommandDialogProps<TCommand, TResponse = object> {
-    command: Constructor<TCommand>;
-    initialValues?: Partial<TCommand>;
-    currentValues?: Partial<TCommand> | undefined;
+export interface CommandDialogProps<TCommand extends object, TResponse = object>
+    extends Omit<CommandFormProps<TCommand>, 'children'> {
     visible: boolean;
     header: string;
     confirmLabel?: string;
     cancelLabel?: string;
-    confirmIcon?: string;
-    cancelIcon?: string;
     onConfirm: (result: ICommandResult<TResponse>) => void | Promise<void>;
     onCancel: () => void;
-    onFieldValidate?: FieldValidator<TCommand>;
-    onFieldChange?: FieldChangeCallback<TCommand>;
-    onBeforeExecute?: BeforeExecuteCallback<TCommand>;
     children?: React.ReactNode;
     style?: React.CSSProperties;
     width?: string;
-    showTitles?: boolean;
-    showErrors?: boolean;
-    validateOn?: CommandFormProps['validateOn'];
-    validateAllFieldsOnChange?: boolean;
-    validateOnInit?: boolean;
-    autoServerValidate?: boolean;
-    autoServerValidateThrottle?: number;
-    fieldContainerComponent?: CommandFormProps['fieldContainerComponent'];
-    fieldDecoratorComponent?: CommandFormProps['fieldDecoratorComponent'];
-    errorDisplayComponent?: CommandFormProps['errorDisplayComponent'];
-    tooltipComponent?: CommandFormProps['tooltipComponent'];
-    errorClassName?: string;
-    iconAddonClassName?: string;
 }
-
-interface CommandDialogContextValue<TCommand = unknown> {
-    onSuccess: (result: ICommandResult<unknown>) => void | Promise<void>;
-    onCancel: () => void;
-    confirmLabel: string;
-    cancelLabel: string;
-    confirmIcon: string;
-    cancelIcon: string;
-    onFieldValidate?: FieldValidator<TCommand>;
-    onFieldChange?: FieldChangeCallback<TCommand>;
-    onBeforeExecute?: BeforeExecuteCallback<TCommand>;
-}
-
-const CommandDialogContext = createContext<CommandDialogContextValue<unknown> | undefined>(undefined);
-
-export const useCommandDialogContext = <TCommand = unknown,>() => {
-    const context = useContext(CommandDialogContext);
-    if (!context) {
-        throw new Error('useCommandDialogContext must be used within a CommandDialog');
-    }
-    return context as CommandDialogContextValue<TCommand>;
-};
 
 const CommandDialogWrapper = <TCommand extends object>({
     header,
@@ -94,13 +44,11 @@ const CommandDialogWrapper = <TCommand extends object>({
     cancelLabel: string;
     onConfirm: (result: ICommandResult<unknown>) => void | Promise<void>;
     onCancel: () => void;
-    onBeforeExecute?: BeforeExecuteCallback<TCommand>;
+    onBeforeExecute?: (values: TCommand) => TCommand;
     children: React.ReactNode;
 }) => {
     const { setCommandValues, setCommandResult, isValid } = useCommandFormContext<TCommand>();
     const commandInstance = useCommandInstance<TCommand>();
-
-    const isDialogValid = isValid;
 
     const handleConfirm = async () => {
         if (onBeforeExecute) {
@@ -150,7 +98,7 @@ const CommandDialogWrapper = <TCommand extends object>({
             buttons={DialogButtons.OkCancel}
             okLabel={confirmLabel}
             cancelLabel={cancelLabel}
-            isValid={isDialogValid}
+            isValid={isValid}
         >
             <div style={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
                 {processedChildren}
@@ -161,85 +109,32 @@ const CommandDialogWrapper = <TCommand extends object>({
 
 const CommandDialogComponent = <TCommand extends object = object, TResponse = object>(props: CommandDialogProps<TCommand, TResponse>) => {
     const {
-        command,
-        initialValues,
-        currentValues,
         visible,
         header,
         confirmLabel = 'Confirm',
         cancelLabel = 'Cancel',
-        confirmIcon = 'pi pi-check',
-        cancelIcon = 'pi pi-times',
         onConfirm,
         onCancel,
-        onFieldValidate,
-        onFieldChange,
-        onBeforeExecute,
         children,
         width = '50vw',
-        showTitles,
-        showErrors,
-        validateOn,
-        validateAllFieldsOnChange,
-        validateOnInit,
-        autoServerValidate,
-        autoServerValidateThrottle,
-        fieldContainerComponent,
-        fieldDecoratorComponent,
-        errorDisplayComponent,
-        tooltipComponent,
-        errorClassName,
-        iconAddonClassName
+        ...commandFormProps
     } = props;
 
-    const contextValue: CommandDialogContextValue<TCommand> = {
-        onSuccess: onConfirm,
-        onCancel,
-        confirmLabel,
-        cancelLabel,
-        confirmIcon,
-        cancelIcon,
-        onFieldValidate,
-        onFieldChange,
-        onBeforeExecute
-    };
-
     return (
-        <CommandDialogContext.Provider value={contextValue}>
-            <CommandForm
-                command={command}
-                initialValues={initialValues}
-                currentValues={currentValues}
-                onFieldValidate={onFieldValidate}
-                onFieldChange={onFieldChange}
-                onBeforeExecute={onBeforeExecute}
-                showTitles={showTitles}
-                showErrors={showErrors}
-                validateOn={validateOn}
-                validateAllFieldsOnChange={validateAllFieldsOnChange}
-                validateOnInit={validateOnInit}
-                autoServerValidate={autoServerValidate}
-                autoServerValidateThrottle={autoServerValidateThrottle}
-                fieldContainerComponent={fieldContainerComponent}
-                fieldDecoratorComponent={fieldDecoratorComponent}
-                errorDisplayComponent={errorDisplayComponent}
-                tooltipComponent={tooltipComponent}
-                errorClassName={errorClassName}
-                iconAddonClassName={iconAddonClassName}>
-                <CommandDialogWrapper
-                    header={header}
-                    visible={visible}
-                    width={width}
-                    confirmLabel={confirmLabel}
-                    cancelLabel={cancelLabel}
-                    onConfirm={onConfirm}
-                    onCancel={onCancel}
-                    onBeforeExecute={onBeforeExecute}
-                >
-                    {children}
-                </CommandDialogWrapper>
-            </CommandForm>
-        </CommandDialogContext.Provider>
+        <CommandForm<TCommand> {...commandFormProps}>
+            <CommandDialogWrapper<TCommand>
+                header={header}
+                visible={visible}
+                width={width}
+                confirmLabel={confirmLabel}
+                cancelLabel={cancelLabel}
+                onConfirm={onConfirm}
+                onCancel={onCancel}
+                onBeforeExecute={commandFormProps.onBeforeExecute}
+            >
+                {children}
+            </CommandDialogWrapper>
+        </CommandForm>
     );
 };
 

--- a/Source/CommandForm/fields/CheckboxField.tsx
+++ b/Source/CommandForm/fields/CheckboxField.tsx
@@ -15,6 +15,7 @@ export const CheckboxField = asCommandFormField<CheckboxFieldComponentProps>(
             <Checkbox
                 checked={props.value}
                 onChange={props.onChange}
+                onBlur={props.onBlur}
                 invalid={props.invalid}
             />
             {props.label && <label className="ml-2">{props.label}</label>}

--- a/Source/CommandForm/fields/DropdownField.tsx
+++ b/Source/CommandForm/fields/DropdownField.tsx
@@ -17,6 +17,7 @@ export const DropdownField = asCommandFormField<DropdownFieldComponentProps>(
         <Dropdown
             value={props.value}
             onChange={(e) => props.onChange(e.value)}
+            onBlur={props.onBlur}
             options={props.options}
             optionValue={props.optionValue}
             optionLabel={props.optionLabel}

--- a/Source/CommandForm/fields/InputTextField.tsx
+++ b/Source/CommandForm/fields/InputTextField.tsx
@@ -16,6 +16,7 @@ export const InputTextField = asCommandFormField<InputTextComponentProps>(
             type={props.type || 'text'}
             value={props.value}
             onChange={props.onChange}
+            onBlur={props.onBlur}
             invalid={props.invalid}
             placeholder={props.placeholder}
             className="w-full"

--- a/Source/CommandForm/fields/NumberField.tsx
+++ b/Source/CommandForm/fields/NumberField.tsx
@@ -17,6 +17,7 @@ export const NumberField = asCommandFormField<NumberFieldComponentProps>(
         <InputNumber
             value={props.value}
             onValueChange={(e) => props.onChange(e.value ?? 0)}
+            onBlur={props.onBlur}
             invalid={props.invalid}
             placeholder={props.placeholder}
             min={props.min}

--- a/Source/CommandForm/fields/SliderField.tsx
+++ b/Source/CommandForm/fields/SliderField.tsx
@@ -13,7 +13,7 @@ interface SliderFieldComponentProps extends WrappedFieldProps<number> {
 
 export const SliderField = asCommandFormField<SliderFieldComponentProps>(
     (props) => (
-        <div className="w-full">
+        <div className="w-full" onBlur={props.onBlur}>
             <Slider
                 value={props.value}
                 onChange={(e) => props.onChange(e.value)}

--- a/Source/CommandForm/fields/TextAreaField.tsx
+++ b/Source/CommandForm/fields/TextAreaField.tsx
@@ -16,6 +16,7 @@ export const TextAreaField = asCommandFormField<TextAreaFieldComponentProps>(
         <InputTextarea
             value={props.value}
             onChange={props.onChange}
+            onBlur={props.onBlur}
             invalid={props.invalid}
             placeholder={props.placeholder}
             rows={props.rows ?? 5}

--- a/Source/package.json
+++ b/Source/package.json
@@ -101,9 +101,9 @@
         "build-storybook": "storybook build"
     },
     "dependencies": {
-        "@cratis/arc": "^19.6.8",
-        "@cratis/arc.react": "^19.6.8",
-        "@cratis/arc.vite": "^19.6.8",
+        "@cratis/arc": "^19.6.9",
+        "@cratis/arc.react": "^19.6.9",
+        "@cratis/arc.vite": "^19.6.9",
         "allotment": "1.20.5",
         "framer-motion": "12.34.3",
         "pixi.js": "^8.16.0",


### PR DESCRIPTION
### Fixed

- Simplifying `CommandDialog` to rely on `CommandForm` for all the heavy lifting and have very little custom logic. This removes quite a few challenges around validation inside it and fixes bugs where the `isValid` is not calculated correctly.
