### PR TITLE
Expose CommandStepper package export and add dialog-frame stories

### DIFF
--- a/Source/CommandDialog/CommandStepper.stories.tsx
+++ b/Source/CommandDialog/CommandStepper.stories.tsx
@@ -9,7 +9,6 @@ import { Command, CommandResult, CommandValidator } from '@cratis/arc/commands';
 import { PropertyDescriptor } from '@cratis/arc/reflection';
 import { InputTextField, NumberField, TextAreaField } from '../CommandForm/fields';
 import '@cratis/arc/validation';
-
 const meta: Meta<typeof CommandStepper> = {
     title: 'CommandDialog/CommandStepper',
     component: CommandStepper,
@@ -117,6 +116,129 @@ export const Default: Story = {
                         {result}
                     </div>
                 )}
+            </div>
+        );
+    },
+};
+
+export const InDialogFrame: Story = {
+    render: () => {
+        const [result, setResult] = useState('');
+
+        return (
+            <div className="command-stepper-stories-background">
+                <div className="command-stepper-stories-frame">
+                    <div className="command-stepper-stories-header">
+                        <h2>Create New Project</h2>
+                    </div>
+                    <div className="command-stepper-stories-content">
+                        <CommandStepper<CreateProjectCommand>
+                            command={CreateProjectCommand}
+                            autoServerValidate={false}
+                            validateOn="change"
+                            onSuccess={async () => setResult('Project created successfully')}
+                        >
+                            <StepperPanel header="Basic Info">
+                                <InputTextField<CreateProjectCommand>
+                                    value={c => c.name}
+                                    title="Project Name"
+                                    placeholder="Enter project name (min 2 chars)"
+                                />
+                                <InputTextField<CreateProjectCommand>
+                                    value={c => c.email}
+                                    title="Contact Email"
+                                    placeholder="Enter contact email"
+                                    type="email"
+                                />
+                            </StepperPanel>
+                            <StepperPanel header="Details">
+                                <TextAreaField<CreateProjectCommand>
+                                    value={c => c.description}
+                                    title="Description"
+                                    placeholder="Describe the project (min 10 chars)"
+                                    rows={4}
+                                />
+                                <NumberField<CreateProjectCommand>
+                                    value={c => c.budget}
+                                    title="Budget"
+                                    placeholder="Enter budget (must be > 0)"
+                                />
+                            </StepperPanel>
+                        </CommandStepper>
+                        {result && (
+                            <div className="p-2 mt-3 border-round surface-100" style={{ border: '1px solid var(--surface-border)' }}>
+                                {result}
+                            </div>
+                        )}
+                    </div>
+                    <div className="command-stepper-stories-footer">
+                        <button className="p-button p-button-secondary">Cancel</button>
+                        <button className="p-button p-button-primary">Create</button>
+                    </div>
+                </div>
+            </div>
+        );
+    },
+};
+
+export const InDialogFrameWithCenteredHeader: Story = {
+    render: () => {
+        const [result, setResult] = useState('');
+
+        return (
+            <div className="command-stepper-stories-background">
+                <div className="command-stepper-stories-frame">
+                    <div className="command-stepper-stories-header command-stepper-stories-header-centered">
+                        <div className="command-stepper-stories-logo">
+                            <div className="command-stepper-stories-logo-placeholder">LOGO</div>
+                            <p className="command-stepper-stories-subtitle">Complete Your Setup</p>
+                        </div>
+                    </div>
+                    <div className="command-stepper-stories-content">
+                        <CommandStepper<CreateProjectCommand>
+                            command={CreateProjectCommand}
+                            autoServerValidate={false}
+                            validateOn="change"
+                            validateOnInit
+                            nextLabel="Continue"
+                            previousLabel="Back"
+                            onSuccess={async () => setResult('Setup completed')}
+                        >
+                            <StepperPanel header="Organization">
+                                <InputTextField<CreateProjectCommand>
+                                    value={c => c.name}
+                                    title="Organization Name"
+                                    placeholder="Enter organization name"
+                                />
+                            </StepperPanel>
+                            <StepperPanel header="Contact">
+                                <InputTextField<CreateProjectCommand>
+                                    value={c => c.email}
+                                    title="Contact Email"
+                                    placeholder="Enter contact email"
+                                    type="email"
+                                />
+                            </StepperPanel>
+                            <StepperPanel header="Details">
+                                <TextAreaField<CreateProjectCommand>
+                                    value={c => c.description}
+                                    title="Description"
+                                    placeholder="Describe your organization"
+                                    rows={3}
+                                />
+                            </StepperPanel>
+                        </CommandStepper>
+                        {result && (
+                            <div className="p-2 mt-3 border-round surface-100" style={{ border: '1px solid var(--surface-border)' }}>
+                                {result}
+                            </div>
+                        )}
+                    </div>
+                    <div className="command-stepper-stories-footer">
+                        <button className="p-button p-button-secondary">Cancel</button>
+                        <button className="p-button p-button-primary">Complete</button>
+                    </div>
+                </div>
             </div>
         );
     },

--- a/Source/index.ts
+++ b/Source/index.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import * as CommandDialog from './CommandDialog';
+import * as CommandStepper from './CommandDialog';
 import * as CommandForm from './CommandForm';
 import * as Common from './Common';
 import * as DataPage from './DataPage';
@@ -18,6 +19,7 @@ import * as Types from './types';
 
 export {
     CommandDialog,
+    CommandStepper,
     CommandForm,
     Common,
     DataPage,

--- a/Source/package.json
+++ b/Source/package.json
@@ -29,6 +29,11 @@
             "require": "./dist/cjs/CommandDialog/index.js",
             "import": "./dist/esm/CommandDialog/index.js"
         },
+        "./CommandStepper": {
+            "types": "./dist/esm/CommandStepper/index.d.ts",
+            "require": "./dist/cjs/CommandStepper/index.js",
+            "import": "./dist/esm/CommandStepper/index.js"
+        },
         "./CommandForm": {
             "types": "./dist/esm/CommandForm/index.d.ts",
             "require": "./dist/cjs/CommandForm/index.js",


### PR DESCRIPTION
## Added
- Added two new `CommandStepper` Storybook stories that render inside realistic dialog-style frames.

## Changed
- Exported `CommandStepper` from the root module exports.
- Added a dedicated `./CommandStepper` package export entry in `Source/package.json`.

## Fixed
- Repaired malformed JSX/TypeScript structure in `CommandStepper.stories.tsx` so the Source build compiles cleanly.