### PR TITLE
feat: Add ToolbarFolder component with dynamic grid layout

### DIFF
--- a/Documentation/Toolbar/folder.md
+++ b/Documentation/Toolbar/folder.md
@@ -1,0 +1,57 @@
+# Expandable Folder
+
+`ToolbarFolder` replaces a regular button with one that reveals a dynamically sized grid of buttons when clicked. The folder animates open to reveal its contents and closes when clicking the button again or anywhere outside the panel.
+
+The grid automatically balances rows and columns based on item count, keeping the folder compact for small sets while naturally expanding for larger collections.
+
+```tsx
+<Toolbar>
+    <ToolbarButton icon='pi pi-arrow-up-left' tooltip='Select' />
+    <ToolbarFolder icon='pi pi-th-large' tooltip='More tools'>
+        <ToolbarButton icon='pi pi-exclamation-circle' tooltip='Info' />
+        <ToolbarButton icon='pi pi-eye' tooltip='Preview' />
+        <ToolbarButton icon='pi pi-cog' tooltip='Settings' />
+        <ToolbarButton icon='pi pi-external-link' tooltip='Open' />
+    </ToolbarFolder>
+</Toolbar>
+```
+
+By default the folder opens to the right. Use `folderDirection='left'` when the toolbar is positioned on the right side of the screen:
+
+```tsx
+<ToolbarFolder icon='pi pi-th-large' tooltip='More tools' folderDirection='left'>
+    ...
+</ToolbarFolder>
+```
+
+## Grid Layout
+
+The folder automatically computes the number of columns based on the item count:
+
+- **1 item:** 1 column × 1 row
+- **4 items:** 2 columns × 2 rows
+- **9 items:** 3 columns × 3 rows
+- **16+ items:** Up to 5 columns (default limit) with multiple rows
+
+Use `maxColumns` to customize the maximum column count:
+
+```tsx
+<ToolbarFolder icon='pi pi-th-large' tooltip='More tools' maxColumns={4}>
+    ...
+</ToolbarFolder>
+```
+
+## ReactNode Icons
+
+Like `ToolbarButton`, the `icon` prop accepts a `string | ReactNode`. Pass any React element as the trigger icon:
+
+```tsx
+import { FaFolder } from 'react-icons/fa6';
+
+<ToolbarFolder icon={<FaFolder />} tooltip='More tools'>
+    <ToolbarButton icon='pi pi-cog' tooltip='Settings' />
+    <ToolbarButton icon='pi pi-external-link' tooltip='Open' />
+</ToolbarFolder>
+```
+
+See [Icon](../../Common/icon.md) for the shared `Icon` type and `IconDisplay` component.

--- a/Documentation/Toolbar/index.md
+++ b/Documentation/Toolbar/index.md
@@ -12,4 +12,5 @@ The `Toolbar` component provides a canvas-style icon toolbar with support for or
 | `ToolbarSection` | Section within a toolbar that animates between named contexts |
 | `ToolbarContext` | Named context (set of buttons) inside a `ToolbarSection` |
 | `ToolbarFanOutItem` | Button that slides out a horizontal sub-panel on click |
+| `ToolbarFolder` | Button that reveals a dynamically sized grid of buttons on click |
 

--- a/Documentation/Toolbar/toc.yml
+++ b/Documentation/Toolbar/toc.yml
@@ -12,6 +12,8 @@
   href: context-switching.md
 - name: Fan-Out Sub-Panel
   href: fan-out.md
+- name: Expandable Folder
+  href: folder.md
 - name: Drag & Drop
   href: drag-and-drop.md
 - name: Multiple Groups

--- a/Source/Toolbar/Toolbar.css
+++ b/Source/Toolbar/Toolbar.css
@@ -164,3 +164,51 @@
     opacity: 1;
     pointer-events: auto;
 }
+
+/* ── Toolbar folder ──────────────────────────────────────────────────────── */
+
+.toolbar-folder-item {
+    position: relative;
+}
+
+/*
+ * Folder panel is a floating grid that grows naturally with item count.
+ * The trigger stays in place while the panel animates in/out.
+ */
+.toolbar-folder-panel {
+    position: absolute;
+    top: 50%;
+    left: calc(100% + 0.75rem);
+    transform: translateY(-50%) scale(0.92);
+    transform-origin: left center;
+    display: grid;
+    grid-auto-rows: minmax(2.5rem, auto);
+    gap: 0.25rem;
+    padding: 0.5rem;
+    background: var(--surface-card);
+    border: 1px solid var(--surface-border);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    border-radius: 1rem;
+    z-index: 10;
+    pointer-events: none;
+    opacity: 0;
+    clip-path: inset(0 100% 0 0 round 1rem);
+    transition:
+        clip-path 0.35s cubic-bezier(0.4, 0, 0.2, 1),
+        transform 0.35s cubic-bezier(0.4, 0, 0.2, 1),
+        opacity 0.2s ease;
+}
+
+.toolbar-folder-panel--left {
+    left: auto;
+    right: calc(100% + 0.75rem);
+    transform-origin: right center;
+    clip-path: inset(0 0 0 100% round 1rem);
+}
+
+.toolbar-folder-panel--visible {
+    clip-path: inset(0 0 0 0 round 1rem);
+    transform: translateY(-50%) scale(1);
+    opacity: 1;
+    pointer-events: auto;
+}

--- a/Source/Toolbar/Toolbar.stories.tsx
+++ b/Source/Toolbar/Toolbar.stories.tsx
@@ -7,6 +7,7 @@ import { Toolbar } from './Toolbar';
 import { ToolbarButton } from './ToolbarButton';
 import { ToolbarContext } from './ToolbarContext';
 import { ToolbarFanOutItem } from './ToolbarFanOutItem';
+import { ToolbarFolder } from './ToolbarFolder';
 import { ToolbarSection } from './ToolbarSection';
 import { ToolbarSeparator } from './ToolbarSeparator';
 
@@ -21,6 +22,29 @@ const meta: Meta<typeof Toolbar> = {
 export default meta;
 
 type Story = StoryObj<typeof Toolbar>;
+
+const folderIcons: string[] = [
+    'pi pi-exclamation-circle',
+    'pi pi-eye',
+    'pi pi-cog',
+    'pi pi-external-link',
+    'pi pi-clock',
+    'pi pi-globe',
+    'pi pi-bookmark',
+    'pi pi-send',
+    'pi pi-search',
+    'pi pi-car',
+    'pi pi-box',
+    'pi pi-bolt',
+    'pi pi-database',
+    'pi pi-cloud',
+    'pi pi-star',
+    'pi pi-heart',
+    'pi pi-map',
+    'pi pi-wifi',
+    'pi pi-lock',
+    'pi pi-bell',
+];
 
 /**
  * Demonstrates that any React node can be used as an icon on {@link ToolbarButton} and
@@ -308,6 +332,49 @@ export const WithFanOut: Story = {
 
         return <WithFanOutDemo />;
     },
+};
+
+/** Demonstrates a folder with a single nested button. */
+export const WithFolderOneButton: Story = {
+    render: () => (
+        <Toolbar>
+            <ToolbarButton icon='pi pi-arrow-up-left' tooltip='Select' />
+            <ToolbarFolder icon='pi pi-th-large' tooltip='Folder (1 item)'>
+                <ToolbarButton icon={folderIcons[0]} tooltip='Action 1' />
+            </ToolbarFolder>
+            <ToolbarButton icon='pi pi-stop' tooltip='Rectangle' />
+        </Toolbar>
+    ),
+};
+
+/** Demonstrates a folder with four nested buttons in a balanced 2x2 grid. */
+export const WithFolderFourButtons: Story = {
+    render: () => (
+        <Toolbar>
+            <ToolbarButton icon='pi pi-arrow-up-left' tooltip='Select' />
+            <ToolbarFolder icon='pi pi-th-large' tooltip='Folder (4 items)'>
+                {folderIcons.slice(0, 4).map((icon, index) => (
+                    <ToolbarButton key={`folder-4-${index}`} icon={icon} tooltip={`Action ${index + 1}`} />
+                ))}
+            </ToolbarFolder>
+            <ToolbarButton icon='pi pi-stop' tooltip='Rectangle' />
+        </Toolbar>
+    ),
+};
+
+/** Demonstrates a folder with twenty nested buttons and dynamic multi-row sizing. */
+export const WithFolderTwentyButtons: Story = {
+    render: () => (
+        <Toolbar>
+            <ToolbarButton icon='pi pi-arrow-up-left' tooltip='Select' />
+            <ToolbarFolder icon='pi pi-th-large' tooltip='Folder (20 items)'>
+                {folderIcons.slice(0, 20).map((icon, index) => (
+                    <ToolbarButton key={`folder-20-${index}`} icon={icon} tooltip={`Action ${index + 1}`} />
+                ))}
+            </ToolbarFolder>
+            <ToolbarButton icon='pi pi-stop' tooltip='Rectangle' />
+        </Toolbar>
+    ),
 };
 
 /**

--- a/Source/Toolbar/ToolbarFolder.tsx
+++ b/Source/Toolbar/ToolbarFolder.tsx
@@ -1,0 +1,105 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Children, ReactNode, useEffect, useMemo, useRef, useState } from 'react';
+import { IconDisplay } from '../Common/Icon';
+import type { Icon } from '../Common/Icon';
+import { Tooltip } from '../Common/Tooltip';
+import type { TooltipPosition } from '../Common/Tooltip';
+
+/** Props for the {@link ToolbarFolder} component. */
+export interface ToolbarFolderProps {
+    /** The icon to display on the folder trigger button. */
+    icon: Icon;
+
+    /** Tooltip text shown when hovering over the folder trigger button. */
+    tooltip: string;
+
+    /** Position of the tooltip relative to the trigger button (default: 'right'). */
+    tooltipPosition?: TooltipPosition;
+
+    /** Direction the folder opens from the trigger button (default: 'right'). */
+    folderDirection?: 'right' | 'left';
+
+    /** Maximum number of columns to render before adding more rows (default: 5). */
+    maxColumns?: number;
+
+    /** The toolbar buttons shown when the folder is expanded. */
+    children: ReactNode;
+}
+
+/**
+ * A toolbar folder that reveals a dynamically sized button grid when clicked.
+ *
+ * The grid keeps a compact footprint for small sets and grows naturally as more
+ * items are added. It also balances rows/columns so large sets remain visually even.
+ */
+export const ToolbarFolder = ({
+    icon,
+    tooltip,
+    tooltipPosition = 'right',
+    folderDirection = 'right',
+    maxColumns = 5,
+    children,
+}: ToolbarFolderProps) => {
+    const [isExpanded, setIsExpanded] = useState(false);
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    const items = useMemo(() => Children.toArray(children).filter(child => child !== null && child !== undefined), [children]);
+    const itemCount = Math.max(1, items.length);
+
+    const columns = useMemo(() => {
+        const upperBound = Math.max(1, maxColumns);
+        const balancedColumns = Math.ceil(Math.sqrt(itemCount));
+        return Math.min(upperBound, balancedColumns);
+    }, [itemCount, maxColumns]);
+
+    const toggleExpanded = () => {
+        setIsExpanded(current => !current);
+    };
+
+    useEffect(() => {
+        if (!isExpanded) {
+            return;
+        }
+
+        const handleClickOutside = (event: MouseEvent) => {
+            if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+                setIsExpanded(false);
+            }
+        };
+
+        document.addEventListener('mousedown', handleClickOutside);
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside);
+        };
+    }, [isExpanded]);
+
+    const activeClass = isExpanded ? 'toolbar-button--active' : '';
+    const panelVisibleClass = isExpanded ? 'toolbar-folder-panel--visible' : '';
+    const directionClass = `toolbar-folder-panel--${folderDirection}`;
+
+    return (
+        <div className='toolbar-folder-item' ref={containerRef}>
+            <Tooltip content={tooltip} position={tooltipPosition}>
+                <button
+                    type='button'
+                    aria-label={tooltip}
+                    aria-expanded={isExpanded}
+                    onClick={toggleExpanded}
+                    className={`toolbar-button w-10 h-10 flex items-center justify-center rounded-lg cursor-pointer ${activeClass}`}
+                >
+                    <IconDisplay icon={icon} className='text-lg' />
+                </button>
+            </Tooltip>
+            <div
+                className={`toolbar-folder-panel ${directionClass} ${panelVisibleClass}`}
+                style={{
+                    gridTemplateColumns: `repeat(${columns}, minmax(2.5rem, 2.5rem))`,
+                }}
+            >
+                {items}
+            </div>
+        </div>
+    );
+};

--- a/Source/Toolbar/index.ts
+++ b/Source/Toolbar/index.ts
@@ -13,3 +13,5 @@ export { ToolbarSeparator } from './ToolbarSeparator';
 export type { ToolbarSeparatorProps } from './ToolbarSeparator';
 export { ToolbarFanOutItem } from './ToolbarFanOutItem';
 export type { ToolbarFanOutItemProps } from './ToolbarFanOutItem';
+export { ToolbarFolder } from './ToolbarFolder';
+export type { ToolbarFolderProps } from './ToolbarFolder';


### PR DESCRIPTION
## Overview
Introduces a new `ToolbarFolder` component that expands a dynamically-sized grid of buttons when clicked, complementing the existing `ToolbarFanOutItem` for organizing larger sets of toolbar actions.

## Changes
- **ToolbarFolder component**: Click-to-toggle expandable folder with balanced grid layout
- **Dynamic sizing**: Grid columns auto-balance based on item count (1x1 for 1 item, 2x2 for 4, 5x4 for 20, etc.)
- **Animation**: Smooth reveal via clip-path + scale + opacity transitions
- **Configuration**: `maxColumns` prop (default: 5) and `folderDirection` prop (left/right)
- **API exports**: Full public component and props types
- **Storybook stories**: 1-button, 4-button, and 20-button demonstration stories
- **Documentation**: Complete guide with layout explanation and usage examples

## Files Changed
- `Source/Toolbar/ToolbarFolder.tsx` — New component (105 lines)
- `Source/Toolbar/Toolbar.css` — New folder panel styles (48 lines)
- `Source/Toolbar/index.ts` — Export ToolbarFolder
- `Source/Toolbar/Toolbar.stories.tsx` — Three demonstration stories
- `Documentation/Toolbar/folder.md` — Usage guide and API reference
- `Documentation/Toolbar/index.md` — Updated components table
- `Documentation/Toolbar/toc.yml` — Added folder documentation entry

## Testing
- Visual verification in Storybook (1/4/20 item grids) ✓
- TypeScript compile check ✓
- CSS validation ✓