### PR TITLE
Fix CommandStepper allowing forward navigation when current step is invalid

### DIFF
--- a/Source/CommandDialog/CommandStepper.tsx
+++ b/Source/CommandDialog/CommandStepper.tsx
@@ -207,6 +207,10 @@ export const CommandStepperContent = ({
         onChangeStep?.(event);
         const index = (event as { index?: number }).index;
         if (typeof index === 'number') {
+            if (index > activeStep && isCurrentStepInvalid) {
+                return;
+            }
+
             if (index > activeStep) {
                 onVisitedStepsChange?.(new Set(visitedSteps).add(activeStep));
             }
@@ -219,6 +223,10 @@ export const CommandStepperContent = ({
     };
 
     const handleNext = () => {
+        if (isCurrentStepInvalid) {
+            return;
+        }
+
         onVisitedStepsChange?.(new Set(visitedSteps).add(activeStep));
         onActiveStepChange?.(Math.min(stepCount - 1, activeStep + 1));
     };


### PR DESCRIPTION
## Fixed
- `CommandStepper` no longer allows advancing to a later step — via the Next button or by clicking a later step tab — when the current step has validation errors.