### PR TITLE
Add ToolbarLayout for dynamic toolbar content regions

### DIFF
--- a/Documentation/Toolbar/toc.yml
+++ b/Documentation/Toolbar/toc.yml
@@ -24,3 +24,5 @@
   href: groups.md
 - name: Slots
   href: slots.md
+  - name: Toolbar Layout
+    href: toolbar-layout.md

--- a/Documentation/Toolbar/toolbar-layout.md
+++ b/Documentation/Toolbar/toolbar-layout.md
@@ -1,0 +1,121 @@
+# Toolbar Layout
+
+`ToolbarLayout` is a named, transparent region inside a `Toolbar` that enables decoupled, dynamically swappable toolbar content. Unlike `ToolbarGroup`, it carries no visual container of its own — the injected content brings its own `ToolbarGroup` pills, `ToolbarSection` context switchers, and `ToolbarSeparator` dividers.
+
+The key capability: any component in the React tree can inject a complete toolbar layout — multiple groups, sections, and separators — into a named region without prop drilling. The injection is coordinated by the `ToolbarSlotProvider`.
+
+## When to use `ToolbarLayout` vs `ToolbarGroup`
+
+| | `ToolbarGroup` | `ToolbarLayout` |
+|---|---|---|
+| Visual container | Yes — renders as a pill | No — transparent pass-through |
+| Slot content | Appended to its own children | Replaces fallback children |
+| Intended content | Individual buttons | Complete toolbar structures (groups, sections, separators) |
+| Use case | Cluster related buttons | Entire swappable toolbar regions |
+
+## Quick Start
+
+Wrap the toolbar and the contributing components in a `ToolbarSlotProvider`. Give `ToolbarLayout` a `name` prop that external components match in their `ToolbarSlot`:
+
+```tsx
+import { ToolbarSlotProvider, ToolbarSlot } from '@cratis/components';
+
+export const AppShell = () => (
+    <ToolbarSlotProvider>
+        <Toolbar>
+            <ToolbarButton icon='pi pi-arrow-up-left' title='Select' />
+            <ToolbarLayout name='canvas-tools'>
+                {/* Fallback — shown when no slot content is registered */}
+                <ToolbarGroup>
+                    <ToolbarButton icon='pi pi-pencil' title='Draw (default)' />
+                </ToolbarGroup>
+            </ToolbarLayout>
+        </Toolbar>
+
+        <CanvasFeature />
+    </ToolbarSlotProvider>
+);
+
+// Anywhere in the tree — injects a complete multi-group layout:
+const CanvasFeature = () => {
+    const content = useMemo(() => (
+        <>
+            <ToolbarGroup>
+                <ToolbarButton icon='pi pi-star' title='Favorite' />
+                <ToolbarButton icon='pi pi-heart' title='Like' />
+            </ToolbarGroup>
+            <ToolbarSeparator />
+            <ToolbarGroup>
+                <ToolbarButton icon='pi pi-bolt' title='Quick action' />
+            </ToolbarGroup>
+        </>
+    ), []);
+
+    return <ToolbarSlot slotName='canvas-tools' order={0}>{content}</ToolbarSlot>;
+};
+```
+
+## Fallback Children
+
+The `children` prop provides default content rendered when no slot content has been registered. As soon as any `ToolbarSlot` with a matching `slotName` mounts, the slot content replaces the fallback completely.
+
+If the layout region has no meaningful default, omit `children` entirely — `ToolbarLayout` renders nothing when both its slot and its children are empty:
+
+```tsx
+{/* No fallback — layout is invisible until a feature registers */}
+<ToolbarLayout name='mode-tools' />
+```
+
+## Multiple Contributors
+
+Multiple components can each register a `ToolbarSlot` with the same `slotName`. The `order` prop on each slot controls the render order (lower values appear first):
+
+```tsx
+// Feature A — appears first
+<ToolbarSlot slotName='shared-tools' order={10}>
+    <ToolbarGroup>
+        <ToolbarButton icon='pi pi-star' title='Feature A' />
+    </ToolbarGroup>
+</ToolbarSlot>
+
+// Feature B — appears second
+<ToolbarSlot slotName='shared-tools' order={20}>
+    <>
+        <ToolbarSeparator />
+        <ToolbarGroup>
+            <ToolbarButton icon='pi pi-cog' title='Feature B' />
+        </ToolbarGroup>
+    </>
+</ToolbarSlot>
+```
+
+## Context-Sensitive Layouts
+
+A common pattern is to render a different slot content based on the active application mode. Mount and unmount (or swap the children of) a single `ToolbarSlot` as the mode changes:
+
+```tsx
+const modeContent = {
+    draw: <DrawingTools />,
+    text: <TextTools />,
+    shape: <ShapeTools />,
+};
+
+// The ToolbarLayout region updates automatically as activeMode changes:
+<ToolbarSlot slotName='mode-tools' order={0}>
+    {modeContent[activeMode]}
+</ToolbarSlot>
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `name` | `string` | required | Identifies the layout region. Match this in `ToolbarSlot` `slotName`. |
+| `children` | `ReactNode` | — | Fallback content shown when no slot content is registered. |
+| `orientation` | `'vertical' \| 'horizontal'` | `'vertical'` | Layout direction — should match the parent `Toolbar`. |
+
+## Related
+
+- [Slots](slots.md) — the slot system that powers `ToolbarLayout`
+- [Groups](groups.md) — `ToolbarGroup` for visually contained button clusters
+- [Context Switching](context-switching.md) — `ToolbarSection` for animated context changes within a slot

--- a/Source/Toolbar/Toolbar.stories.tsx
+++ b/Source/Toolbar/Toolbar.stories.tsx
@@ -12,6 +12,7 @@ import { ToolbarGroup } from './ToolbarGroup';
 import { ToolbarSection } from './ToolbarSection';
 import { ToolbarSeparator } from './ToolbarSeparator';
 import { ToolbarSlot, ToolbarSlotProvider } from './ToolbarSlot';
+import { ToolbarLayout } from './ToolbarLayout';
 
 const meta: Meta<typeof Toolbar> = {
     title: 'Components/Toolbar',
@@ -717,3 +718,287 @@ export const WithMultipleSlotContributors: Story = {
         );
     },
 };
+
+    // ─── ToolbarLayout stories ────────────────────────────────────────────────────
+
+    /**
+     * Demonstrates {@link ToolbarLayout} rendering its fallback children when no slot
+     * content has been registered. The layout acts as a transparent container so the
+     * injected {@link ToolbarGroup} pills appear exactly as they would if placed
+     * directly inside the {@link Toolbar}.
+     */
+    export const LayoutWithDefaultContent: Story = {
+        render: () => (
+            <Toolbar>
+                <ToolbarButton icon='pi pi-arrow-up-left' title='Select' />
+                <ToolbarLayout name='feature-tools'>
+                    <ToolbarGroup>
+                        <ToolbarButton icon='pi pi-pencil' title='Draw (default)' />
+                        <ToolbarButton icon='pi pi-stop' title='Rectangle (default)' />
+                    </ToolbarGroup>
+                </ToolbarLayout>
+                <ToolbarButton icon='pi pi-undo' title='Undo' />
+            </Toolbar>
+        ),
+    };
+
+    /**
+     * Shows a feature injecting a complete toolbar layout — multiple groups and a
+     * separator — into a named {@link ToolbarLayout} region from anywhere in the tree.
+     * Toggle the "Feature mounted" switch to see the layout region swap between the
+     * default content and the injected content.
+     */
+    export const LayoutWithInjectedContent: Story = {
+        render: () => {
+            const LayoutWithInjectedContentDemo = () => {
+                const [featureMounted, setFeatureMounted] = useState(true);
+
+                const featureContent = useMemo(
+                    () => (
+                        <>
+                            <ToolbarGroup>
+                                <ToolbarButton icon='pi pi-star' title='Favorite' />
+                                <ToolbarButton icon='pi pi-heart' title='Like' />
+                            </ToolbarGroup>
+                            <ToolbarSeparator />
+                            <ToolbarGroup>
+                                <ToolbarButton icon='pi pi-bolt' title='Quick action' />
+                            </ToolbarGroup>
+                        </>
+                    ),
+                    []
+                );
+
+                return (
+                    <ToolbarSlotProvider>
+                        <div className='flex flex-col items-center gap-6'>
+                            <Toolbar orientation='horizontal'>
+                                <ToolbarButton icon='pi pi-arrow-up-left' title='Select' tooltipPosition='bottom' />
+                                <ToolbarSeparator orientation='horizontal' />
+                                <ToolbarLayout name='feature-tools' orientation='horizontal'>
+                                    <ToolbarGroup orientation='horizontal'>
+                                        <ToolbarButton icon='pi pi-pencil' title='Draw (default)' tooltipPosition='bottom' />
+                                        <ToolbarButton icon='pi pi-stop' title='Rectangle (default)' tooltipPosition='bottom' />
+                                    </ToolbarGroup>
+                                </ToolbarLayout>
+                                <ToolbarSeparator orientation='horizontal' />
+                                <ToolbarButton icon='pi pi-undo' title='Undo' tooltipPosition='bottom' />
+                            </Toolbar>
+
+                            {featureMounted && (
+                                <ToolbarSlot slotName='feature-tools' order={0}>
+                                    {featureContent}
+                                </ToolbarSlot>
+                            )}
+
+                            <div className='flex flex-col items-center gap-2'>
+                                <span className='text-xs' style={{ color: 'var(--text-color-secondary)' }}>
+                                    Feature mounted
+                                </span>
+                                <button
+                                    type='button'
+                                    onClick={() => setFeatureMounted(m => !m)}
+                                    className={`px-3 py-1 rounded text-sm transition-colors ${
+                                        featureMounted
+                                            ? 'bg-blue-600 text-white'
+                                            : 'bg-gray-600 text-gray-200 hover:bg-gray-500'
+                                    }`}
+                                >
+                                    {featureMounted ? 'Unmount feature' : 'Mount feature'}
+                                </button>
+                            </div>
+                        </div>
+                    </ToolbarSlotProvider>
+                );
+            };
+
+            return <LayoutWithInjectedContentDemo />;
+        },
+    };
+
+    /**
+     * Demonstrates two independent features each contributing to the same
+     * {@link ToolbarLayout} region. The `order` prop on each {@link ToolbarSlot} controls
+     * which contribution appears first — lower values appear before higher ones.
+     * Toggle each feature to see how the layout region adapts.
+     */
+    export const LayoutWithMultipleContributors: Story = {
+        render: () => {
+            const LayoutWithMultipleContributorsDemo = () => {
+                const [featureAMounted, setFeatureAMounted] = useState(true);
+                const [featureBMounted, setFeatureBMounted] = useState(true);
+
+                const featureAContent = useMemo(
+                    () => (
+                        <ToolbarGroup>
+                            <ToolbarButton icon='pi pi-star' title='Feature A — Favorite (order 10)' />
+                            <ToolbarButton icon='pi pi-heart' title='Feature A — Like (order 10)' />
+                        </ToolbarGroup>
+                    ),
+                    []
+                );
+
+                const featureBContent = useMemo(
+                    () => (
+                        <>
+                            <ToolbarSeparator />
+                            <ToolbarGroup>
+                                <ToolbarButton icon='pi pi-bolt' title='Feature B — Quick action (order 20)' />
+                                <ToolbarButton icon='pi pi-cog' title='Feature B — Settings (order 20)' />
+                            </ToolbarGroup>
+                        </>
+                    ),
+                    []
+                );
+
+                return (
+                    <ToolbarSlotProvider>
+                        <div className='flex flex-col items-center gap-6'>
+                            <Toolbar>
+                                <ToolbarButton icon='pi pi-arrow-up-left' title='Select' />
+                                <ToolbarLayout name='shared-region'>
+                                    <ToolbarGroup>
+                                        <ToolbarButton icon='pi pi-pencil' title='Draw (default)' />
+                                    </ToolbarGroup>
+                                </ToolbarLayout>
+                                <ToolbarButton icon='pi pi-undo' title='Undo' />
+                            </Toolbar>
+
+                            {featureAMounted && (
+                                <ToolbarSlot slotName='shared-region' order={10}>
+                                    {featureAContent}
+                                </ToolbarSlot>
+                            )}
+
+                            {featureBMounted && (
+                                <ToolbarSlot slotName='shared-region' order={20}>
+                                    {featureBContent}
+                                </ToolbarSlot>
+                            )}
+
+                            <div className='flex gap-6'>
+                                {[
+                                    { label: 'Feature A', mounted: featureAMounted, toggle: () => setFeatureAMounted(m => !m) },
+                                    { label: 'Feature B', mounted: featureBMounted, toggle: () => setFeatureBMounted(m => !m) },
+                                ].map(({ label, mounted, toggle }) => (
+                                    <div key={label} className='flex flex-col items-center gap-2'>
+                                        <span className='text-xs' style={{ color: 'var(--text-color-secondary)' }}>{label}</span>
+                                        <button
+                                            type='button'
+                                            onClick={toggle}
+                                            className={`px-3 py-1 rounded text-sm transition-colors ${
+                                                mounted
+                                                    ? 'bg-blue-600 text-white'
+                                                    : 'bg-gray-600 text-gray-200 hover:bg-gray-500'
+                                            }`}
+                                        >
+                                            {mounted ? 'Unmount' : 'Mount'}
+                                        </button>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    </ToolbarSlotProvider>
+                );
+            };
+
+            return <LayoutWithMultipleContributorsDemo />;
+        },
+    };
+
+    /**
+     * Shows how a {@link ToolbarLayout} with context-sensitive slot content mirrors
+     * the application's active mode. Each "mode" has its own feature component that
+     * mounts and unmounts a {@link ToolbarSlot} — the layout region swaps its full
+     * content automatically and independently from the rest of the toolbar.
+     */
+    export const LayoutWithContextSensitiveContent: Story = {
+        render: () => {
+            const LayoutWithContextSensitiveContentDemo = () => {
+                const [activeMode, setActiveMode] = useState<'draw' | 'text' | 'shape'>('draw');
+
+                const drawContent = useMemo(
+                    () => (
+                        <>
+                            <ToolbarGroup>
+                                <ToolbarButton icon='pi pi-pencil' title='Freehand' />
+                                <ToolbarButton icon='pi pi-minus' title='Line' />
+                            </ToolbarGroup>
+                            <ToolbarSeparator />
+                            <ToolbarGroup>
+                                <ToolbarButton icon='pi pi-eraser' title='Erase' />
+                            </ToolbarGroup>
+                        </>
+                    ),
+                    []
+                );
+
+                const textContent = useMemo(
+                    () => (
+                        <ToolbarGroup>
+                            <ToolbarButton icon='pi pi-align-left' title='Align left' />
+                            <ToolbarButton icon='pi pi-align-center' title='Center' />
+                            <ToolbarButton icon='pi pi-align-right' title='Align right' />
+                        </ToolbarGroup>
+                    ),
+                    []
+                );
+
+                const shapeContent = useMemo(
+                    () => (
+                        <>
+                            <ToolbarGroup>
+                                <ToolbarButton icon='pi pi-stop' title='Rectangle' />
+                                <ToolbarButton icon='pi pi-circle' title='Circle' />
+                            </ToolbarGroup>
+                            <ToolbarSeparator />
+                            <ToolbarGroup>
+                                <ToolbarButton icon='pi pi-clone' title='Duplicate' />
+                            </ToolbarGroup>
+                        </>
+                    ),
+                    []
+                );
+
+                const modeContent = { draw: drawContent, text: textContent, shape: shapeContent };
+
+                return (
+                    <ToolbarSlotProvider>
+                        <div className='flex flex-col items-center gap-6'>
+                            <Toolbar>
+                                <ToolbarButton icon='pi pi-arrow-up-left' title='Select' />
+                                <ToolbarLayout name='mode-tools' />
+                                <ToolbarButton icon='pi pi-undo' title='Undo' />
+                            </Toolbar>
+
+                            <ToolbarSlot slotName='mode-tools' order={0}>
+                                {modeContent[activeMode]}
+                            </ToolbarSlot>
+
+                            <div className='flex flex-col items-center gap-2'>
+                                <span className='text-xs' style={{ color: 'var(--text-color-secondary)' }}>Active mode</span>
+                                <div className='flex gap-2'>
+                                    {(['draw', 'text', 'shape'] as const).map(mode => (
+                                        <button
+                                            key={mode}
+                                            type='button'
+                                            onClick={() => setActiveMode(mode)}
+                                            className={`px-3 py-1 rounded text-sm capitalize transition-colors ${
+                                                activeMode === mode
+                                                    ? 'bg-blue-600 text-white'
+                                                    : 'bg-gray-600 text-gray-200 hover:bg-gray-500'
+                                            }`}
+                                        >
+                                            {mode}
+                                        </button>
+                                    ))}
+                                </div>
+                            </div>
+                        </div>
+                    </ToolbarSlotProvider>
+                );
+            };
+
+            return <LayoutWithContextSensitiveContentDemo />;
+        },
+    };

--- a/Source/Toolbar/ToolbarLayout.tsx
+++ b/Source/Toolbar/ToolbarLayout.tsx
@@ -1,0 +1,83 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { ReactNode } from 'react';
+import { useToolbarSlot } from './ToolbarSlot';
+
+/** Props for the {@link ToolbarLayout} component. */
+export interface ToolbarLayoutProps {
+    /**
+     * The name identifying this layout region.
+     * External components use this as the `slotName` on a {@link ToolbarSlot} to inject content.
+     */
+    name: string;
+
+    /**
+     * Default content shown when no slot content has been registered for this layout.
+     * Can include {@link ToolbarGroup}, {@link ToolbarSection}, {@link ToolbarSeparator},
+     * or any other toolbar elements.
+     */
+    children?: ReactNode;
+
+    /** Layout direction matching the parent {@link Toolbar} (default: `'vertical'`). */
+    orientation?: 'vertical' | 'horizontal';
+}
+
+/**
+ * A named, transparent layout region inside a {@link Toolbar} that enables decoupled,
+ * dynamically swappable toolbar content.
+ *
+ * Unlike {@link ToolbarGroup}, `ToolbarLayout` has no visual container of its own.
+ * It acts as a transparent mount point: external components inject complete toolbar
+ * structures — multiple {@link ToolbarGroup}s, {@link ToolbarSection}s,
+ * {@link ToolbarSeparator}s — using a {@link ToolbarSlot} with a matching `slotName`.
+ *
+ * When any slot content is registered it replaces the fallback `children`. Multiple
+ * independent contributors can register into the same layout using different `order`
+ * values on their {@link ToolbarSlot}.
+ *
+ * Wrap the toolbar and contributing components in a {@link ToolbarSlotProvider}:
+ *
+ * @example
+ * ```tsx
+ * // Application shell — define the layout region with optional fallback content:
+ * <ToolbarSlotProvider>
+ *     <Toolbar>
+ *         <ToolbarButton icon="pi pi-arrow-up-left" title="Select" />
+ *         <ToolbarLayout name="canvas-tools">
+ *             <ToolbarGroup>
+ *                 <ToolbarButton icon="pi pi-pencil" title="Draw (default)" />
+ *             </ToolbarGroup>
+ *         </ToolbarLayout>
+ *     </Toolbar>
+ *
+ *     <CanvasFeature />
+ * </ToolbarSlotProvider>
+ *
+ * // Feature component — inject complete groups:
+ * const CanvasFeature = () => (
+ *     <ToolbarSlot slotName="canvas-tools">
+ *         <ToolbarGroup>
+ *             <ToolbarButton icon="pi pi-star" title="Feature tool" />
+ *         </ToolbarGroup>
+ *         <ToolbarSeparator />
+ *         <ToolbarGroup>
+ *             <ToolbarButton icon="pi pi-bolt" title="Quick action" />
+ *         </ToolbarGroup>
+ *     </ToolbarSlot>
+ * );
+ * ```
+ */
+export const ToolbarLayout = ({ name, children, orientation = 'vertical' }: ToolbarLayoutProps) => {
+    const slotItems = useToolbarSlot(name);
+    const flexClass = orientation === 'horizontal' ? 'flex-row' : 'flex-col';
+
+    const content = slotItems.length > 0 ? slotItems : children;
+    if (content == null) return null;
+
+    return (
+        <div className={`toolbar-layout inline-flex ${flexClass} items-center gap-1`}>
+            {content}
+        </div>
+    );
+};

--- a/Source/Toolbar/index.ts
+++ b/Source/Toolbar/index.ts
@@ -20,3 +20,5 @@ export type { ToolbarFolderProps } from './ToolbarFolder';
 export type { ToolbarFolderMode } from './ToolbarFolderContext';
 export { ToolbarSlot, ToolbarSlotProvider, useToolbarSlot } from './ToolbarSlot';
 export type { ToolbarSlotProps, ToolbarSlotProviderProps } from './ToolbarSlot';
+export { ToolbarLayout } from './ToolbarLayout';
+export type { ToolbarLayoutProps } from './ToolbarLayout';


### PR DESCRIPTION
## Added
- Added `ToolbarLayout` as a transparent, named toolbar region that renders fallback children or slot-contributed content.
- Added dedicated `ToolbarLayout` documentation with usage patterns for fallback, multiple contributors, and context-sensitive layouts.

## Changed
- Added `ToolbarLayout` stories demonstrating default content, injected layouts, multi-contributor composition, and context-sensitive swapping.
- Exported `ToolbarLayout` and `ToolbarLayoutProps` from the Toolbar public API.
- Updated Toolbar documentation TOC to include the new Toolbar Layout page.