### PR TITLE
Fix package dependency classification for UI runtime libraries

### DIFF
--- a/Source/package.json
+++ b/Source/package.json
@@ -128,39 +128,23 @@
     },
     "dependencies": {
         "react-icons": "5.6.0",
-        "ts-deepmerge": "8.0.0"
-    },
-    "devDependencies": {
-        "@cratis/arc.vite": "^20.3.1",
+        "ts-deepmerge": "8.0.0",
         "allotment": "1.20.5",
         "framer-motion": "12.40.0",
         "pixi.js": "^8.17.1",
         "primeicons": "7.0.0",
         "primereact": "10.9.8"
     },
+    "devDependencies": {
+        "@cratis/arc.vite": "^20.3.1"
+    },
     "peerDependencies": {
         "@cratis/arc": "^20.3.1",
         "@cratis/arc.react": "^20.3.1",
         "@cratis/fundamentals": "^7.10.3",
-        "allotment": "^1.20.0",
-        "framer-motion": "^12.0.0",
-        "pixi.js": "^8.0.0",
-        "primeicons": "^7.0.0",
-        "primereact": "^10.9.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "reflect-metadata": "0.2.2",
         "tsyringe": "4.10.0"
-    },
-    "peerDependenciesMeta": {
-        "allotment": {
-            "optional": true
-        },
-        "framer-motion": {
-            "optional": true
-        },
-        "pixi.js": {
-            "optional": true
-        }
     }
 }


### PR DESCRIPTION
## Changed
- Move UI runtime libraries (allotment, framer-motion, pixi.js, primeicons, primereact) from peer dependencies to dependencies for package consumers.
- Keep only framework-level peers (React, Cratis Arc, fundamentals, reflect-metadata, tsyringe) as peer dependencies.

## Removed
- Remove optional peer dependency metadata for libraries now included as runtime dependencies.