### PR TITLE
Make Storybook page full-page with nav visible

### DIFF
--- a/Documentation/storybook.mdx
+++ b/Documentation/storybook.mdx
@@ -1,13 +1,8 @@
 ---
 title: Storybook
 description: Browse every Cratis component live — props, states, and variations — in an interactive Storybook.
+tableOfContents: false
 ---
 import StorybookEmbed from '@components/StorybookEmbed.astro';
 
-Every Cratis component ships with **stories** — live, interactive examples you can poke at.
-Toggle props, switch between states, and read the rendered output without writing a line of
-setup. It's the fastest way to see what a component does before you reach for it.
-
-Browse the full catalog below, or use the controls panel to drive each component's props.
-
-<StorybookEmbed />
+<StorybookEmbed fullPage={true} />


### PR DESCRIPTION
## Changed
- Storybook documentation page now fills the entire content area with Storybook's own story navigation and controls panel visible