### PR TITLE
Set default Storybook layout to show sidebar, toolbar, and addons panel

### DIFF
--- a/Source/.storybook/manager.js
+++ b/Source/.storybook/manager.js
@@ -9,6 +9,11 @@ let currentTheme = urlParams.get('docsSiteTheme') ?? 'dark';
 
 addons.setConfig({
     theme: currentTheme === 'light' ? themes.light : themes.dark,
+    navSize: 300,
+    bottomPanelHeight: 300,
+    panelPosition: 'bottom',
+    showToolbar: true,
+    showTabs: true,
 });
 
 // Relay the current theme to the preview canvas whenever a story renders,


### PR DESCRIPTION
## Changed
- Storybook now always opens with the sidebar, toolbar, and addons panel (Controls/Actions/Interactions) visible, regardless of any previous browser localStorage state.