### PR TITLE
Harden component usage contracts (icons, onBeforeExecute, ESLint rules)

### DIFF
--- a/ESLint/README.md
+++ b/ESLint/README.md
@@ -7,8 +7,10 @@ Cratis base config, [`@cratis/eslint-config`](https://www.npmjs.com/package/@cra
 |---|---|
 | `no-root-barrel-import` | Disallows importing from the `@cratis/components` root barrel. Use a subpath export (`@cratis/components/CommandDialog`, `@cratis/components/DataPage`, `@cratis/components/Toolbar`, …) — the root pulls the whole optional-peer-heavy surface and hides intent. |
 | `no-primereact-dialog` | Disallows importing `Dialog` from `primereact/dialog`. Use `CommandDialog` from `@cratis/components/CommandDialog`, or `Dialog` from `@cratis/components/Dialogs` — the wrappers add Arc command binding, overlay/focus fixes, and theming. |
+| `onbeforeexecute-must-return` | Requires an `onBeforeExecute` callback to return the command values. `onBeforeExecute` is a transformer — a body that can complete without returning executes the command with `undefined` (silent data loss). |
+| `no-hooks-in-view-model` | Disallows React hooks (including generated Arc proxies' `.use()`) inside a view model class. View models must be plain, hook-free classes that receive injected abstractions. |
 
-Both cover `import` and re-`export … from` forms.
+The two import rules cover `import` and re-`export … from` forms.
 
 ## Install
 
@@ -41,3 +43,56 @@ export default [
     source: 'primereact/dialog',        // module to forbid
 }],
 ```
+
+`onbeforeexecute-must-return` and `no-hooks-in-view-model` take no options.
+
+## Rules
+
+### `onbeforeexecute-must-return`
+
+`onBeforeExecute` (on `CommandDialog`, `StepperCommandDialog`, `CommandScope`, …) is a
+**transformer**: it receives the current command values and must **return** them (mutated or
+not). A callback that returns nothing runs the command with `undefined` — every field is
+wiped at submit time. TypeScript catches this at fully-typed call sites; this rule is the
+backstop for JavaScript and loosely-typed consumers.
+
+```tsx
+// ✅ returns the values
+<CommandDialog onBeforeExecute={values => { values.id = Guid.create(); return values; }} />
+<CommandDialog onBeforeExecute={values => values} />
+
+// ❌ side-effect only — command executes with undefined
+<CommandDialog onBeforeExecute={values => { values.id = Guid.create(); }} />
+// ❌ bare return
+<CommandDialog onBeforeExecute={values => { return; }} />
+```
+
+It flags JSX attribute (`onBeforeExecute={…}`), object property (`{ onBeforeExecute: … }`),
+and variable (`const onBeforeExecute = …`) forms. It is a lint backstop, not a full
+control-flow analysis: a callback that returns a value on some branches but can still fall
+through is not flagged.
+
+### `no-hooks-in-view-model`
+
+A view model is plain TypeScript — it must never call React hooks. `react-hooks/rules-of-hooks`
+does not reliably flag hooks called from **class methods**, so this rule fills the gap for
+Cratis MVVM view models. Inject an abstraction (`IIdentityProvider`, `IMessenger`, a query
+service) instead of calling a hook.
+
+```ts
+// ❌ generated Arc proxy hook inside a view model
+class AuthorsViewModel {
+    load() { const [authors] = AllAuthors.use(); }   // flagged
+}
+
+// ✅ inject the abstraction; call hooks only in the component
+@injectable
+class AuthorsViewModel {
+    constructor(private readonly identity: IIdentityProvider) {}
+}
+```
+
+A class is treated as a view model when it is registered via `withViewModel(...)`, decorated
+with `@injectable`, or named `*ViewModel`. Both bare hooks (`useState`, `useIdentity`, …) and
+proxy member hooks (`.use()`, `.useSuspense()`, `.useChangeStream()`) are flagged. Hooks
+inside a nested non–view-model class are not.

--- a/ESLint/index.js
+++ b/ESLint/index.js
@@ -1,6 +1,8 @@
 import { createRequire } from 'node:module';
 import { noPrimereactDialog } from './lib/noPrimereactDialog.js';
 import { noRootBarrelImport } from './lib/noRootBarrelImport.js';
+import { onbeforeexecuteMustReturn } from './lib/onbeforeexecuteMustReturn.js';
+import { noHooksInViewModel } from './lib/noHooksInViewModel.js';
 
 const { version } = createRequire(import.meta.url)('./package.json');
 
@@ -13,6 +15,8 @@ const plugin = {
     rules: {
         'no-primereact-dialog': noPrimereactDialog,
         'no-root-barrel-import': noRootBarrelImport,
+        'onbeforeexecute-must-return': onbeforeexecuteMustReturn,
+        'no-hooks-in-view-model': noHooksInViewModel,
     },
     configs: {},
 };
@@ -31,6 +35,8 @@ Object.assign(plugin.configs, {
             rules: {
                 '@cratis/components/no-primereact-dialog': 'error',
                 '@cratis/components/no-root-barrel-import': 'error',
+                '@cratis/components/onbeforeexecute-must-return': 'error',
+                '@cratis/components/no-hooks-in-view-model': 'error',
             },
         },
     ],
@@ -38,4 +44,4 @@ Object.assign(plugin.configs, {
 
 export default plugin;
 export const { configs, rules, meta } = plugin;
-export { noPrimereactDialog, noRootBarrelImport };
+export { noPrimereactDialog, noRootBarrelImport, onbeforeexecuteMustReturn, noHooksInViewModel };

--- a/ESLint/lib/noHooksInViewModel.js
+++ b/ESLint/lib/noHooksInViewModel.js
@@ -1,0 +1,122 @@
+const HOOK_IDENTIFIER = /^use[A-Z0-9]/;
+// Matches a `.use(...)` / `.useSuspense(...)` / `.useChangeStream(...)` member call — the
+// shape of a generated Arc query/command proxy hook — as well as bare `useX()` hooks.
+const HOOK_MEMBER = /^use([A-Z0-9]|$)/;
+
+const decoratorName = (decorator) => {
+    const expression = decorator.expression;
+    if (!expression) return undefined;
+    if (expression.type === 'Identifier') return expression.name;
+    if (expression.type === 'CallExpression' && expression.callee?.type === 'Identifier') {
+        return expression.callee.name;
+    }
+    return undefined;
+};
+
+const hasInjectableDecorator = (classNode) => {
+    const decorators = classNode.decorators ?? [];
+    return decorators.some((decorator) => decoratorName(decorator) === 'injectable');
+};
+
+const isHookCall = (node) => {
+    const callee = node.callee;
+    if (!callee) return false;
+    if (callee.type === 'Identifier') return HOOK_IDENTIFIER.test(callee.name);
+    if (callee.type === 'MemberExpression' && callee.property?.type === 'Identifier' && !callee.computed) {
+        return HOOK_MEMBER.test(callee.property.name);
+    }
+    return false;
+};
+
+// Walk a class body for hook calls, without descending into a nested class (a different
+// subject) — but still descend through the view model's own methods and getters.
+const forEachHookCall = (node, visit) => {
+    if (!node || typeof node.type !== 'string') return;
+    if (node.type === 'ClassDeclaration' || node.type === 'ClassExpression') return;
+    if (node.type === 'CallExpression' && isHookCall(node)) {
+        visit(node);
+    }
+    for (const key of Object.keys(node)) {
+        if (key === 'parent') continue;
+        const child = node[key];
+        if (Array.isArray(child)) {
+            for (const item of child) forEachHookCall(item, visit);
+        } else {
+            forEachHookCall(child, visit);
+        }
+    }
+};
+
+// Forbid React hooks (including generated Arc proxies' `.use()`) inside a class that is a
+// view model — one registered via `withViewModel`, decorated with `@injectable`, or named
+// `*ViewModel`. `react-hooks/rules-of-hooks` does not reliably flag hooks called from class
+// methods; a view model must be plain, hook-free TypeScript and receive injected
+// abstractions instead.
+export const noHooksInViewModel = {
+    meta: {
+        type: 'problem',
+        docs: {
+            description: 'Disallow React hooks (including Arc proxy .use()) inside a view model class.',
+            recommended: true,
+            url: 'https://github.com/Cratis/Components/blob/main/ESLint/README.md',
+        },
+        schema: [],
+        messages: {
+            noHook: "Do not call the hook '{{name}}' inside a view model. View models must be plain, hook-free classes — inject the abstraction (IIdentityProvider, IMessenger, a query service) instead.",
+        },
+    },
+    create(context) {
+        const registeredViewModels = new Set();
+        const classNodes = [];
+
+        const nameOfCallee = (callee) => {
+            if (!callee) return undefined;
+            if (callee.type === 'Identifier') return callee.name;
+            if (callee.type === 'MemberExpression' && callee.property?.type === 'Identifier') {
+                return callee.property.name;
+            }
+            return undefined;
+        };
+
+        const hookName = (node) => {
+            const callee = node.callee;
+            if (callee.type === 'Identifier') return callee.name;
+            if (callee.type === 'MemberExpression' && callee.property?.type === 'Identifier') {
+                return `.${callee.property.name}`;
+            }
+            return 'hook';
+        };
+
+        const collectClass = (node) => {
+            classNodes.push(node);
+        };
+
+        return {
+            CallExpression(node) {
+                if (nameOfCallee(node.callee) !== 'withViewModel') return;
+                const first = node.arguments[0];
+                if (first?.type === 'Identifier') {
+                    registeredViewModels.add(first.name);
+                }
+            },
+            ClassDeclaration: collectClass,
+            ClassExpression: collectClass,
+            'Program:exit'() {
+                for (const classNode of classNodes) {
+                    const name = classNode.id?.name;
+                    const isViewModel =
+                        (name && /ViewModel$/.test(name)) ||
+                        hasInjectableDecorator(classNode) ||
+                        (name && registeredViewModels.has(name));
+                    if (!isViewModel) continue;
+
+                    forEachHookCall(classNode.body, (call) => {
+                        context.report({ node: call, messageId: 'noHook', data: { name: hookName(call) } });
+                    });
+                }
+            },
+        };
+    },
+};
+
+export default noHooksInViewModel;

--- a/ESLint/lib/onbeforeexecuteMustReturn.js
+++ b/ESLint/lib/onbeforeexecuteMustReturn.js
@@ -1,0 +1,107 @@
+// Collect every `return` statement that belongs directly to `functionBody`, without
+// descending into nested functions (their returns are not this function's returns) or into
+// a return's own argument (which may itself contain a nested arrow).
+const collectOwnReturns = (node, returns) => {
+    if (!node || typeof node.type !== 'string') return;
+    if (node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression' || node.type === 'ArrowFunctionExpression') {
+        return;
+    }
+    if (node.type === 'ReturnStatement') {
+        returns.push(node);
+        return;
+    }
+    for (const key of Object.keys(node)) {
+        if (key === 'parent') continue;
+        const child = node[key];
+        if (Array.isArray(child)) {
+            for (const item of child) collectOwnReturns(item, returns);
+        } else {
+            collectOwnReturns(child, returns);
+        }
+    }
+};
+
+const keyNameOf = (key) => {
+    if (!key) return undefined;
+    if (key.type === 'Identifier') return key.name;
+    if (key.type === 'Literal') return String(key.value);
+    return undefined;
+};
+
+// True when `node` is the function assigned to an `onBeforeExecute` binding — a JSX
+// attribute (`onBeforeExecute={...}`), an object property (`{ onBeforeExecute: ... }`), or a
+// variable (`const onBeforeExecute = ...`).
+const isOnBeforeExecuteCallback = (node) => {
+    const parent = node.parent;
+    if (!parent) return false;
+
+    if (parent.type === 'JSXExpressionContainer' &&
+        parent.parent?.type === 'JSXAttribute' &&
+        parent.parent.name?.name === 'onBeforeExecute') {
+        return true;
+    }
+
+    if ((parent.type === 'Property' || parent.type === 'PropertyDefinition') &&
+        parent.value === node &&
+        keyNameOf(parent.key) === 'onBeforeExecute') {
+        return true;
+    }
+
+    if (parent.type === 'VariableDeclarator' &&
+        parent.init === node &&
+        parent.id?.type === 'Identifier' &&
+        parent.id.name === 'onBeforeExecute') {
+        return true;
+    }
+
+    return false;
+};
+
+// Require an `onBeforeExecute` callback to return the command values on every path. It is a
+// transformer, not a side-effect hook: a body that can complete without returning executes
+// the command with `undefined` (silent data loss). A lint backstop for consumers whose call
+// sites are not fully typed — it flags a block-bodied callback that returns nothing, or a
+// bare `return;`. It does not do full path analysis, so a callback that returns a value on
+// some branches but can still fall through is not flagged.
+export const onbeforeexecuteMustReturn = {
+    meta: {
+        type: 'problem',
+        docs: {
+            description: 'Require an onBeforeExecute callback to return the command values; returning nothing executes the command with undefined.',
+            recommended: true,
+            url: 'https://github.com/Cratis/Components/blob/main/ESLint/README.md',
+        },
+        schema: [],
+        messages: {
+            missingReturn: 'onBeforeExecute is a transformer and must return the command values. This callback can complete without returning, which executes the command with undefined values. Return the values (mutated or not).',
+            emptyReturn: 'onBeforeExecute must return the command values, not `return;`. Return the values (mutated or not).',
+        },
+    },
+    create(context) {
+        const check = (node) => {
+            if (!isOnBeforeExecuteCallback(node)) return;
+            // An expression-bodied arrow (`values => values`) always returns a value.
+            if (node.type === 'ArrowFunctionExpression' && node.body.type !== 'BlockStatement') return;
+
+            const returns = [];
+            collectOwnReturns(node.body, returns);
+
+            const emptyReturn = returns.find((statement) => !statement.argument);
+            if (emptyReturn) {
+                context.report({ node: emptyReturn, messageId: 'emptyReturn' });
+                return;
+            }
+
+            if (returns.length === 0) {
+                context.report({ node, messageId: 'missingReturn' });
+            }
+        };
+
+        return {
+            ArrowFunctionExpression: check,
+            FunctionExpression: check,
+        };
+    },
+};
+
+export default onbeforeexecuteMustReturn;

--- a/ESLint/package.json
+++ b/ESLint/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@cratis/eslint-plugin-components",
     "version": "0.0.0",
-    "description": "Cratis Components ESLint rules: import from subpaths, not the root barrel, and use the Cratis dialog wrappers instead of primereact/dialog. Compose on top of @cratis/eslint-config.",
+    "description": "Cratis Components ESLint rules: import from subpaths not the root barrel, use the Cratis dialog wrappers instead of primereact/dialog, require onBeforeExecute callbacks to return their values, and keep React hooks out of view models. Compose on top of @cratis/eslint-config.",
     "author": "Cratis",
     "license": "MIT",
     "type": "module",

--- a/ESLint/test/rules.test.js
+++ b/ESLint/test/rules.test.js
@@ -1,7 +1,10 @@
 import { RuleTester } from 'eslint';
 import { afterAll, describe, it } from 'vitest';
+import tsParser from '@typescript-eslint/parser';
 import { noPrimereactDialog } from '../lib/noPrimereactDialog.js';
 import { noRootBarrelImport } from '../lib/noRootBarrelImport.js';
+import { onbeforeexecuteMustReturn } from '../lib/onbeforeexecuteMustReturn.js';
+import { noHooksInViewModel } from '../lib/noHooksInViewModel.js';
 
 RuleTester.afterAll = afterAll;
 RuleTester.describe = describe;
@@ -10,6 +13,16 @@ RuleTester.itOnly = it.only;
 
 const ruleTester = new RuleTester({
     languageOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+});
+
+// A tester using the TypeScript parser for JSX and decorator syntax.
+const tsRuleTester = new RuleTester({
+    languageOptions: {
+        parser: tsParser,
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        parserOptions: { ecmaFeatures: { jsx: true } },
+    },
 });
 
 ruleTester.run('no-root-barrel-import', noRootBarrelImport, {
@@ -61,6 +74,71 @@ ruleTester.run('no-primereact-dialog', noPrimereactDialog, {
         {
             code: "export { Dialog } from 'primereact/dialog';",
             errors: [{ messageId: 'useWrapper' }],
+        },
+    ],
+});
+
+tsRuleTester.run('onbeforeexecute-must-return', onbeforeexecuteMustReturn, {
+    valid: [
+        // Expression-bodied arrow always returns.
+        "const a = <CommandDialog onBeforeExecute={values => values} />;",
+        // Block body that returns the values.
+        "const b = <CommandDialog onBeforeExecute={(values) => { values.id = '1'; return values; }} />;",
+        // Object property form.
+        "const c = { onBeforeExecute: (v) => v };",
+        // Variable form.
+        "const onBeforeExecute = (v) => { return v; };",
+        // A nested callback returning nothing does not count against the outer return.
+        "const d = <CommandDialog onBeforeExecute={(v) => { [1].forEach(() => {}); return v; }} />;",
+        // Unrelated callbacks are never flagged, even when they return nothing.
+        "const e = <button onClick={() => { doThing(); }} />;",
+    ],
+    invalid: [
+        {
+            code: "const a = <CommandDialog onBeforeExecute={(values) => { doSideEffect(values); }} />;",
+            errors: [{ messageId: 'missingReturn' }],
+        },
+        {
+            code: "const b = <CommandDialog onBeforeExecute={function (values) { doSideEffect(values); }} />;",
+            errors: [{ messageId: 'missingReturn' }],
+        },
+        {
+            code: "const c = <CommandDialog onBeforeExecute={(values) => { return; }} />;",
+            errors: [{ messageId: 'emptyReturn' }],
+        },
+        {
+            code: "const d = { onBeforeExecute: (v) => { log(v); } };",
+            errors: [{ messageId: 'missingReturn' }],
+        },
+    ],
+});
+
+tsRuleTester.run('no-hooks-in-view-model', noHooksInViewModel, {
+    valid: [
+        // A view model with no hooks.
+        "class FooViewModel { select(id) { this.selected = id; } }",
+        // A *ViewModel calling a plain method is fine.
+        "class BarViewModel { compute() { return this.transform(); } }",
+        // A non-view-model class may use hooks (it is a component/helper, not a VM).
+        "class Helper { render() { const x = useState(0); return x; } }",
+        // An injectable view model with only injected collaborators.
+        "@injectable class BazViewModel { constructor(private readonly svc) {} load() { return this.svc.get(); } }",
+    ],
+    invalid: [
+        {
+            // Generated Arc proxy .use() inside a *ViewModel.
+            code: "class FooViewModel { load() { const [x] = AllAuthors.use(); return x; } }",
+            errors: [{ messageId: 'noHook', data: { name: '.use' } }],
+        },
+        {
+            // A React hook inside an @injectable view model.
+            code: "@injectable class Bar { method() { const s = useState(0); return s; } }",
+            errors: [{ messageId: 'noHook', data: { name: 'useState' } }],
+        },
+        {
+            // A class registered via withViewModel, even without the naming/decorator signals.
+            code: "class Vm { method() { useIdentity(); } } const C = withViewModel(Vm, () => null);",
+            errors: [{ messageId: 'noHook', data: { name: 'useIdentity' } }],
         },
     ],
 });

--- a/Source/CommandDialog/CommandDialog.tsx
+++ b/Source/CommandDialog/CommandDialog.tsx
@@ -12,6 +12,7 @@ import {
     useCommandInstance,
     type CommandFormProps
 } from '@cratis/arc.react/commands';
+import { applyBeforeExecute, type BeforeExecuteCallback } from './applyBeforeExecute';
 
 /**
  * Props for {@link CommandDialog}. Combines the props of a `CommandForm`
@@ -23,8 +24,23 @@ import {
  * @typeParam TResponse - The response payload type returned by a successful command. Defaults to `object`.
  */
 export interface CommandDialogProps<TCommand extends object, TResponse = object>
-    extends Omit<CommandFormProps<TCommand, TResponse>, 'children'>,
+    extends Omit<CommandFormProps<TCommand, TResponse>, 'children' | 'onBeforeExecute'>,
         Omit<DialogProps, 'children'> {
+    /**
+     * A transformer invoked with the current command values immediately before
+     * the command executes on confirm. It **must return** the values to run with
+     * (mutated or not) — a callback that returns nothing does not execute the
+     * command with `undefined`; the current values are kept and a warning is
+     * logged. May be async.
+     *
+     * ⚠️ It runs **only on submit**, after the form has already been validated,
+     * so a value produced here can never satisfy required-field validation — the
+     * submit button stays disabled if a required value is only seeded here. Seed
+     * required values through `initialValues`; reserve `onBeforeExecute` for
+     * transforms that do not affect validity (for example a generated id).
+     */
+    onBeforeExecute?: BeforeExecuteCallback<TCommand>;
+
     /**
      * Form fields and arbitrary content for the dialog body. Children that are
      * `CommandFormField` instances are automatically wrapped so they bind to
@@ -77,7 +93,7 @@ const CommandDialogWrapper = <TCommand extends object, TResponse = object>({
     onSuccess?: CommandFormProps<TCommand, TResponse>['onSuccess'];
     onValidationFailure?: CommandFormProps<TCommand, TResponse>['onValidationFailure'];
     onFailed?: CommandFormProps<TCommand, TResponse>['onFailed'];
-    onBeforeExecute?: (values: TCommand) => TCommand;
+    onBeforeExecute?: BeforeExecuteCallback<TCommand>;
     className?: DialogProps['className'];
     pt?: DialogProps['pt'];
     ptOptions?: DialogProps['ptOptions'];
@@ -90,8 +106,8 @@ const CommandDialogWrapper = <TCommand extends object, TResponse = object>({
 
     const handleConfirm = async () => {
         if (onBeforeExecute) {
-            const transformedValues = onBeforeExecute(commandInstance);
-            setCommandValues(transformedValues);
+            const applied = applyBeforeExecute(onBeforeExecute, commandInstance);
+            setCommandValues(applied instanceof Promise ? await applied : applied);
         }
 
         setIsBusy(true);
@@ -288,6 +304,7 @@ const CommandDialogComponent = <TCommand extends object = object, TResponse = ob
         onClose,
         onConfirm,
         onCancel,
+        onBeforeExecute,
         className,
         pt,
         ptOptions,
@@ -317,7 +334,7 @@ const CommandDialogComponent = <TCommand extends object = object, TResponse = ob
                 onSuccess={props.onSuccess}
                 onValidationFailure={props.onValidationFailure}
                 onFailed={props.onFailed}
-                onBeforeExecute={commandFormProps.onBeforeExecute}
+                onBeforeExecute={onBeforeExecute}
                 className={className}
                 pt={pt}
                 ptOptions={ptOptions}

--- a/Source/CommandDialog/CommandStepper.tsx
+++ b/Source/CommandDialog/CommandStepper.tsx
@@ -12,6 +12,7 @@ import {
     useCommandInstance,
     type CommandFormProps
 } from '@cratis/arc.react/commands';
+import { applyBeforeExecute, type BeforeExecuteCallback } from './applyBeforeExecute';
 import './CommandStepper.css';
 
 /**
@@ -58,8 +59,21 @@ export interface CommandStepperContentProps extends StepperCustomizationProps {
 }
 
 export interface CommandStepperProps<TCommand extends object, TResponse = object>
-    extends Omit<CommandFormProps<TCommand, TResponse>, 'children'>,
+    extends Omit<CommandFormProps<TCommand, TResponse>, 'children' | 'onBeforeExecute'>,
         Omit<CommandStepperContentProps, 'activeStep' | 'visitedSteps' | 'onActiveStepChange' | 'onVisitedStepsChange' | 'getFieldError' | 'isSubmitting' | 'isSubmitDisabled' | 'onSubmit'> {
+    /**
+     * A transformer invoked with the current command values immediately before
+     * the command executes on submit. It **must return** the values to run with
+     * (mutated or not) — a callback that returns nothing does not execute the
+     * command with `undefined`; the current values are kept and a warning is
+     * logged. May be async.
+     *
+     * ⚠️ It runs **only on submit**, after every step has already been validated,
+     * so a value produced here can never satisfy required-field validation. Seed
+     * required values through `initialValues`; reserve `onBeforeExecute` for
+     * transforms that do not affect validity (for example a generated id).
+     */
+    onBeforeExecute?: BeforeExecuteCallback<TCommand>;
     /** StepperPanel children defining each wizard step. */
     children?: React.ReactNode;
 }
@@ -299,7 +313,7 @@ type CommandStepperWrapperProps<TCommand extends object, TResponse = object> =
         onSuccess?: CommandFormProps<TCommand, TResponse>['onSuccess'];
         onValidationFailure?: CommandFormProps<TCommand, TResponse>['onValidationFailure'];
         onFailed?: CommandFormProps<TCommand, TResponse>['onFailed'];
-        onBeforeExecute?: (values: TCommand) => TCommand;
+        onBeforeExecute?: BeforeExecuteCallback<TCommand>;
     };
 
 const CommandStepperWrapper = <TCommand extends object, TResponse = object>({
@@ -333,8 +347,8 @@ const CommandStepperWrapper = <TCommand extends object, TResponse = object>({
 
     const handleSubmit = async () => {
         if (onBeforeExecute) {
-            const transformedValues = onBeforeExecute(commandInstance);
-            setCommandValues(transformedValues);
+            const applied = applyBeforeExecute(onBeforeExecute, commandInstance);
+            setCommandValues(applied instanceof Promise ? await applied : applied);
         }
 
         setIsSubmitting(true);
@@ -472,6 +486,7 @@ export const CommandStepper = <TCommand extends object = object, TResponse = obj
         pt,
         ptOptions,
         unstyled,
+        onBeforeExecute,
         ...commandFormProps
     } = props;
 
@@ -497,7 +512,7 @@ export const CommandStepper = <TCommand extends object = object, TResponse = obj
                 onSuccess={props.onSuccess}
                 onValidationFailure={props.onValidationFailure}
                 onFailed={props.onFailed}
-                onBeforeExecute={commandFormProps.onBeforeExecute}
+                onBeforeExecute={onBeforeExecute}
             >
                 {children}
             </CommandStepperWrapper>

--- a/Source/CommandDialog/StepperCommandDialog.tsx
+++ b/Source/CommandDialog/StepperCommandDialog.tsx
@@ -14,6 +14,7 @@ import {
 } from '@cratis/arc.react/commands';
 import type { CloseDialog, ConfirmCallback, CancelCallback } from '../Dialogs/Dialog';
 import { CommandStepperContent, type StepperCustomizationProps } from './CommandStepper';
+import { applyBeforeExecute, type BeforeExecuteCallback } from './applyBeforeExecute';
 
 /**
  * Props for {@link StepperCommandDialog}. Combines the command-form props,
@@ -28,8 +29,21 @@ import { CommandStepperContent, type StepperCustomizationProps } from './Command
  * @typeParam TResponse - The response payload type returned by a successful command.
  */
 export interface StepperCommandDialogProps<TCommand extends object, TResponse = object>
-    extends Omit<CommandFormProps<TCommand, TResponse>, 'children'>,
+    extends Omit<CommandFormProps<TCommand, TResponse>, 'children' | 'onBeforeExecute'>,
         StepperCustomizationProps {
+    /**
+     * A transformer invoked with the current command values immediately before
+     * the command executes on submit. It **must return** the values to run with
+     * (mutated or not) — a callback that returns nothing does not execute the
+     * command with `undefined`; the current values are kept and a warning is
+     * logged. May be async.
+     *
+     * ⚠️ It runs **only on submit**, after every step has already been validated,
+     * so a value produced here can never satisfy required-field validation. Seed
+     * required values through `initialValues`; reserve `onBeforeExecute` for
+     * transforms that do not affect validity (for example a generated id).
+     */
+    onBeforeExecute?: BeforeExecuteCallback<TCommand>;
     /** Dialog title text. */
     title: string;
     /** Controls dialog visibility. Defaults to `true`. */
@@ -117,7 +131,7 @@ const StepperCommandDialogWrapper = <TCommand extends object, TResponse = object
     onSuccess?: CommandFormProps<TCommand, TResponse>['onSuccess'];
     onValidationFailure?: CommandFormProps<TCommand, TResponse>['onValidationFailure'];
     onFailed?: CommandFormProps<TCommand, TResponse>['onFailed'];
-    onBeforeExecute?: (values: TCommand) => TCommand;
+    onBeforeExecute?: BeforeExecuteCallback<TCommand>;
     okLabel?: string;
     nextLabel?: string;
     previousLabel?: string;
@@ -179,8 +193,8 @@ const StepperCommandDialogWrapper = <TCommand extends object, TResponse = object
 
     const handleSubmit = async () => {
         if (onBeforeExecute) {
-            const transformedValues = onBeforeExecute(commandInstance);
-            setCommandValues(transformedValues);
+            const applied = applyBeforeExecute(onBeforeExecute, commandInstance);
+            setCommandValues(applied instanceof Promise ? await applied : applied);
         }
 
         setIsBusy(true);
@@ -391,6 +405,7 @@ const StepperCommandDialogComponent = <TCommand extends object = object, TRespon
         onClose,
         onConfirm,
         onCancel,
+        onBeforeExecute,
         okLabel,
         nextLabel,
         previousLabel,
@@ -427,7 +442,7 @@ const StepperCommandDialogComponent = <TCommand extends object = object, TRespon
                 onSuccess={props.onSuccess}
                 onValidationFailure={props.onValidationFailure}
                 onFailed={props.onFailed}
-                onBeforeExecute={commandFormProps.onBeforeExecute}
+                onBeforeExecute={onBeforeExecute}
                 okLabel={okLabel}
                 nextLabel={nextLabel}
                 previousLabel={previousLabel}

--- a/Source/CommandDialog/applyBeforeExecute.ts
+++ b/Source/CommandDialog/applyBeforeExecute.ts
@@ -1,0 +1,59 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+ * A transformer invoked with the current command values immediately before the
+ * command executes. It **must return** the values to run with (mutated or not),
+ * and may do so asynchronously.
+ *
+ * ⚠️ It runs **only on submit**, after the form has already been validated — so a
+ * value produced here can never satisfy required-field validation and the submit
+ * button stays disabled if you rely on it for a required value. Seed required
+ * values through `initialValues`; reserve `onBeforeExecute` for transforms that do
+ * not affect validity (for example a generated id).
+ *
+ * @typeParam TCommand - The command values type.
+ */
+export type BeforeExecuteCallback<TCommand> = (values: TCommand) => TCommand | Promise<TCommand>;
+
+/**
+ * Applies an `onBeforeExecute` transformer safely.
+ *
+ * The typed callback contract requires the transformed values to be returned, but
+ * JavaScript consumers (and mistyped call sites) can still return `undefined` by
+ * using the callback as a side-effect hook. Executing with `undefined` would wipe
+ * every command value — silent data loss at submit time. This guard treats a
+ * missing return as "keep the current values" and warns, so the command always
+ * executes with a real object.
+ *
+ * A **synchronous** callback is applied synchronously (the result is returned
+ * directly, not wrapped in a promise) so the command values are set before the same
+ * tick's execution proceeds; an **async** callback returns a promise to await.
+ *
+ * @typeParam TCommand - The command values type.
+ * @param onBeforeExecute - The transformer to apply (sync or async).
+ * @param currentValues - The command values to transform.
+ * @returns The transformed values, or `currentValues` when the callback returned nothing.
+ */
+export function applyBeforeExecute<TCommand>(
+    onBeforeExecute: BeforeExecuteCallback<TCommand>,
+    currentValues: TCommand
+): TCommand | Promise<TCommand> {
+    const transformed = onBeforeExecute(currentValues);
+    if (transformed instanceof Promise) {
+        return transformed.then((resolved) => keepCurrentWhenMissing(resolved, currentValues));
+    }
+    return keepCurrentWhenMissing(transformed, currentValues);
+}
+
+function keepCurrentWhenMissing<TCommand>(transformed: TCommand | undefined, currentValues: TCommand): TCommand {
+    if (transformed === undefined) {
+        console.warn(
+            'onBeforeExecute returned no value. It is a transformer and must return the command values ' +
+            '(mutated or not). Keeping the current values so the command does not execute with undefined. ' +
+            'If you only need a side effect, return the values you received.'
+        );
+        return currentValues;
+    }
+    return transformed;
+}

--- a/Source/CommandDialog/for_applyBeforeExecute/when_callback_is_async.ts
+++ b/Source/CommandDialog/for_applyBeforeExecute/when_callback_is_async.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { applyBeforeExecute } from '../applyBeforeExecute';
+
+describe('when applyBeforeExecute is given an async callback', () => {
+    let result: { id: string };
+
+    beforeEach(async () => {
+        result = await applyBeforeExecute(
+            async (values) => ({ ...values, id: 'async-generated' }),
+            { id: '' }
+        );
+    });
+
+    it('should_await_and_return_the_transformed_values', () => {
+        result.id.should.equal('async-generated');
+    });
+});

--- a/Source/CommandDialog/for_applyBeforeExecute/when_callback_returns_nothing.ts
+++ b/Source/CommandDialog/for_applyBeforeExecute/when_callback_returns_nothing.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { vi } from 'vitest';
+import { applyBeforeExecute, type BeforeExecuteCallback } from '../applyBeforeExecute';
+
+describe('when applyBeforeExecute is given a callback that returns nothing', () => {
+    const current = { id: 'original' };
+    let result: { id: string };
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    // A JavaScript consumer using onBeforeExecute as a side-effect hook — it forgets to
+    // return the values. The typed contract forbids this; the cast simulates the untyped
+    // call site the runtime guard exists to protect.
+    const sideEffectOnly = ((values: { id: string }) => { void values; }) as unknown as BeforeExecuteCallback<{ id: string }>;
+
+    beforeEach(async () => {
+        warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { /* silence during the spec */ });
+        result = await applyBeforeExecute(sideEffectOnly, current);
+    });
+
+    afterEach(() => {
+        warnSpy.mockRestore();
+    });
+
+    it('should_keep_the_current_values', () => {
+        result.should.equal(current);
+    });
+
+    it('should_never_return_undefined', () => {
+        (result === undefined).should.be.false;
+    });
+
+    it('should_warn_about_the_missing_return', () => {
+        warnSpy.mock.calls.length.should.equal(1);
+    });
+});

--- a/Source/CommandDialog/for_applyBeforeExecute/when_callback_transforms_values.ts
+++ b/Source/CommandDialog/for_applyBeforeExecute/when_callback_transforms_values.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { applyBeforeExecute } from '../applyBeforeExecute';
+
+describe('when applyBeforeExecute is given a transforming callback', () => {
+    const current = { id: '', name: 'Ada' };
+    let result: { id: string; name: string };
+
+    beforeEach(async () => {
+        result = await applyBeforeExecute((values) => ({ ...values, id: 'generated' }), current);
+    });
+
+    it('should_return_the_transformed_values', () => {
+        result.id.should.equal('generated');
+    });
+
+    it('should_preserve_untouched_values', () => {
+        result.name.should.equal('Ada');
+    });
+});

--- a/Source/CommandDialog/index.ts
+++ b/Source/CommandDialog/index.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+export * from './applyBeforeExecute';
 export * from './CommandDialog';
 export * from './CommandStepper';
 export * from './StepperCommandDialog';

--- a/Source/Common/Icon.stories.tsx
+++ b/Source/Common/Icon.stories.tsx
@@ -25,6 +25,38 @@ export const StringIconWithExtraClass: Story = {
     render: () => <IconDisplay icon='pi pi-home' className='text-3xl' />,
 };
 
+/**
+ * A lone PrimeIcons class (`'pi-home'`) missing its required base `pi` class is repaired to
+ * `'pi pi-home'` so it still renders — a common mistake that otherwise shows nothing.
+ */
+export const PiClassMissingBase: Story = {
+    render: () => <IconDisplay icon='pi-home' className='text-3xl' />,
+};
+
+/**
+ * A bare icon name (`'plus'`) is not a CSS class and renders nothing — passing one logs a
+ * development warning pointing at the full `'pi pi-plus'` class. Shown here next to the
+ * correct usage for contrast.
+ */
+export const BareIconNameWarns: Story = {
+    render: () => (
+        <div style={{ display: 'flex', gap: '2rem', alignItems: 'center' }}>
+            <div style={{ textAlign: 'center' }}>
+                <IconDisplay icon='plus' className='text-2xl' />
+                <p style={{ fontSize: '0.75rem', marginTop: '0.5rem', color: 'var(--cratis-text-color-secondary)' }}>
+                    'plus' (bare name — warns, renders nothing)
+                </p>
+            </div>
+            <div style={{ textAlign: 'center' }}>
+                <IconDisplay icon='pi pi-plus' className='text-2xl' />
+                <p style={{ fontSize: '0.75rem', marginTop: '0.5rem', color: 'var(--cratis-text-color-secondary)' }}>
+                    'pi pi-plus' (correct)
+                </p>
+            </div>
+        </div>
+    ),
+};
+
 /** Renders an SVG React node directly — no wrapping `<i>` element is produced. */
 export const SvgReactNode: Story = {
     render: () => (

--- a/Source/Common/Icon.tsx
+++ b/Source/Common/Icon.tsx
@@ -2,6 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { ReactNode } from 'react';
+import { normalizeIconClass } from './normalizeIconClass';
+
+// Module-scoped ambient so the dev-only warning below type-checks without pulling in Node
+// types (the library's tsconfig sets `types: []`). Bundlers replace `process.env.NODE_ENV`
+// with a literal; the `typeof` guard keeps it safe where `process` is genuinely absent.
+declare const process: { env: Record<string, string | undefined> };
 
 /**
  * Represents an icon that can be either a PrimeIcons CSS class string (e.g. `'pi pi-home'`)
@@ -22,13 +28,23 @@ export interface IconDisplayProps {
  * Renders an {@link Icon} value.
  *
  * - When `icon` is a non-empty string it is treated as a PrimeIcons (or other icon-font)
- *   CSS class and rendered as `<i className={icon} />`.
+ *   CSS class and rendered as `<i className={icon} />`. A lone PrimeIcons class missing its
+ *   base `pi` class (`'pi-home'`) is repaired to `'pi pi-home'`, and a bare icon name
+ *   (`'plus'`) that would silently render nothing logs a development warning.
  * - Otherwise the value is rendered as-is, allowing any React node (SVG, component, etc.)
  *   to be used as an icon.
  */
 export const IconDisplay = ({ icon, className }: IconDisplayProps) => {
-    if (typeof icon === 'string' && icon.length > 0) {
-        const combined = className ? `${icon} ${className}` : icon;
+    if (typeof icon === 'string') {
+        const { className: resolved, warning } = normalizeIconClass(icon);
+        const isDevelopment = typeof process === 'undefined' || process.env.NODE_ENV !== 'production';
+        if (warning && isDevelopment) {
+            console.warn(warning);
+        }
+        if (resolved.length === 0) {
+            return <></>;
+        }
+        const combined = className ? `${resolved} ${className}` : resolved;
         return <i className={combined} />;
     }
     return <>{icon}</>;

--- a/Source/Common/for_IconDisplay/when_icon_is_a_pi_class_without_base/and_rendered.ts
+++ b/Source/Common/for_IconDisplay/when_icon_is_a_pi_class_without_base/and_rendered.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { IconDisplay } from '../../Icon';
+
+describe('when IconDisplay is given a pi class missing its base class and rendered', () => {
+    let html: string;
+
+    beforeEach(() => {
+        const element = React.createElement(IconDisplay, { icon: 'pi-home' });
+        html = renderToStaticMarkup(element);
+    });
+
+    it('should_render_an_i_element', () => {
+        html.should.include('<i');
+    });
+
+    it('should_apply_the_repaired_class_with_base_pi', () => {
+        html.should.include('pi pi-home');
+    });
+});

--- a/Source/Common/for_normalizeIconClass/when_given_a_bare_icon_name.ts
+++ b/Source/Common/for_normalizeIconClass/when_given_a_bare_icon_name.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { normalizeIconClass } from '../normalizeIconClass';
+
+describe('when normalizeIconClass is given a bare icon name', () => {
+    const result = normalizeIconClass('plus');
+
+    it('should_leave_the_class_untouched', () => {
+        result.className.should.equal('plus');
+    });
+
+    it('should_warn_that_it_is_not_a_class', () => {
+        (result.warning === undefined).should.be.false;
+    });
+
+    it('should_suggest_the_prime_icons_class', () => {
+        (result.warning ?? '').should.include('pi pi-plus');
+    });
+});

--- a/Source/Common/for_normalizeIconClass/when_given_a_full_class_string.ts
+++ b/Source/Common/for_normalizeIconClass/when_given_a_full_class_string.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { normalizeIconClass } from '../normalizeIconClass';
+
+describe('when normalizeIconClass is given a full class string', () => {
+    const result = normalizeIconClass('pi pi-home');
+
+    it('should_return_the_class_unchanged', () => {
+        result.className.should.equal('pi pi-home');
+    });
+
+    it('should_not_produce_a_warning', () => {
+        (result.warning === undefined).should.be.true;
+    });
+});

--- a/Source/Common/for_normalizeIconClass/when_given_a_pi_class_without_base.ts
+++ b/Source/Common/for_normalizeIconClass/when_given_a_pi_class_without_base.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { normalizeIconClass } from '../normalizeIconClass';
+
+describe('when normalizeIconClass is given a pi class without its base class', () => {
+    const result = normalizeIconClass('pi-home');
+
+    it('should_prepend_the_base_pi_class', () => {
+        result.className.should.equal('pi pi-home');
+    });
+
+    it('should_not_produce_a_warning', () => {
+        (result.warning === undefined).should.be.true;
+    });
+});

--- a/Source/Common/for_normalizeIconClass/when_given_an_empty_string.ts
+++ b/Source/Common/for_normalizeIconClass/when_given_an_empty_string.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { normalizeIconClass } from '../normalizeIconClass';
+
+describe('when normalizeIconClass is given a whitespace-only string', () => {
+    const result = normalizeIconClass('   ');
+
+    it('should_return_an_empty_class', () => {
+        result.className.should.equal('');
+    });
+
+    it('should_not_produce_a_warning', () => {
+        (result.warning === undefined).should.be.true;
+    });
+});

--- a/Source/Common/index.ts
+++ b/Source/Common/index.ts
@@ -4,6 +4,7 @@
 export * from './CratisComponentsProvider';
 export * from './ErrorBoundary';
 export * from './Icon';
+export * from './normalizeIconClass';
 export * from './Page';
 export * from './FormElement';
 export * from './Tooltip';

--- a/Source/Common/normalizeIconClass.ts
+++ b/Source/Common/normalizeIconClass.ts
@@ -1,0 +1,61 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/** The outcome of normalizing a string icon value into a renderable CSS class. */
+export interface NormalizedIconClass {
+    /** The CSS class to apply to the `<i>` element. Empty when there is nothing to render. */
+    className: string;
+
+    /**
+     * A developer-facing warning when the input looks like a bare icon name rather than a
+     * CSS class (e.g. `'plus'` instead of `'pi pi-plus'`). Present only when the value would
+     * render nothing recognizable as an icon.
+     */
+    warning?: string;
+}
+
+/**
+ * Normalizes a string icon value into a CSS class for {@link IconDisplay}.
+ *
+ * A string icon is meant to be a full icon-font CSS class such as `'pi pi-home'`. Two
+ * mistakes silently render nothing — and look like the icon "just doesn't work":
+ *
+ * - A lone PrimeIcons class (`'pi-home'`) missing its required base `pi` class. This is
+ *   unambiguous, so it is repaired to `'pi pi-home'`.
+ * - A bare icon name (`'plus'`, `'home'`) that is not a CSS class at all. There is no safe
+ *   way to know which icon font it belongs to, so the value is left untouched and a warning
+ *   is produced pointing at the full class (`'pi pi-plus'`) or a React node.
+ *
+ * Full class strings (anything containing whitespace) and already-prefixed values pass
+ * through unchanged.
+ *
+ * @param icon - The raw string icon value.
+ * @returns The class to render and an optional developer warning.
+ */
+export function normalizeIconClass(icon: string): NormalizedIconClass {
+    const trimmed = icon.trim();
+    if (trimmed.length === 0) {
+        return { className: '' };
+    }
+
+    // A full class string (multiple tokens) is taken as-is — the caller spelled it out.
+    if (trimmed.includes(' ')) {
+        return { className: trimmed };
+    }
+
+    // A lone PrimeIcons icon class missing its base `pi` class — repair it.
+    if (trimmed.startsWith('pi-')) {
+        return { className: `pi pi-${trimmed.slice('pi-'.length)}` };
+    }
+
+    // A single plain word (no hyphen, no prefix) is almost certainly a bare icon name that
+    // will not render. Leave rendering untouched but guide the caller to the real class.
+    if (trimmed !== 'pi' && /^[a-z][a-z0-9]*$/i.test(trimmed)) {
+        return {
+            className: trimmed,
+            warning: `IconDisplay received '${trimmed}', which looks like a bare icon name rather than a CSS class, so it will not render as an icon. Use a full icon class such as 'pi pi-${trimmed}', or pass a React node.`,
+        };
+    }
+
+    return { className: trimmed };
+}


### PR DESCRIPTION
# Summary

Closes three ways the library lets consumers write code that silently misbehaves: string icons that render nothing, `onBeforeExecute` callbacks that wipe command values, and view models that call hooks.

## Added

- `onBeforeExecute` on `CommandDialog`, `StepperCommandDialog`, and `CommandStepper` now accepts an async callback returning `Promise<T>`.
- `@cratis/eslint-plugin-components` rule `onbeforeexecute-must-return`, flagging an `onBeforeExecute` callback that can complete without returning the command values.
- `@cratis/eslint-plugin-components` rule `no-hooks-in-view-model`, flagging React hooks and Arc proxy `.use()` calls inside a view model class.

## Changed

- `IconDisplay` now repairs a lone PrimeIcons class missing its base class (`pi-home` → `pi pi-home`) so it renders, and warns in development when given a bare icon name (e.g. `plus`) that is not a CSS class.

## Fixed

- `onBeforeExecute` no longer executes the command with `undefined` values when a callback returns nothing — the current values are kept and a warning is logged.