### PR TITLE
Upgrade actions/cache from v3 to v4

### DIFF
--- a/.github/workflows/javascript-build.yml
+++ b/.github/workflows/javascript-build.yml
@@ -37,7 +37,7 @@ jobs:
           node-version: 23.x
           registry-url: "https://registry.npmjs.org"
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: yarn-cache
         with:
           path: |


### PR DESCRIPTION
## Changed

- Continuous integration caching uses `actions/cache@v4`.
