### PR TITLE
Support Arc 21

### DIFF
--- a/Source/package.json
+++ b/Source/package.json
@@ -141,11 +141,11 @@
         "ts-deepmerge": "8.0.0"
     },
     "devDependencies": {
-        "@cratis/arc.vite": "^20.49.2"
+        "@cratis/arc.vite": "^21.0.2"
     },
     "peerDependencies": {
-        "@cratis/arc": "^20.3.1",
-        "@cratis/arc.react": "^20.3.1",
+        "@cratis/arc": ">=20.3.1 <22",
+        "@cratis/arc.react": ">=20.3.1 <22",
         "@cratis/fundamentals": "^7.10.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",

--- a/Source/vite.config.ts
+++ b/Source/vite.config.ts
@@ -31,7 +31,10 @@ export default defineConfig({
     test: {
         globals: true,
         environment: 'node',
-        isolate: false,
+        // Isolated, because several spec files mock the same module (@cratis/arc.react/dialogs) with
+        // their own spies. With a shared module graph whichever file loaded first wins and the others
+        // observe zero calls, which showed up as an intermittent "expected one closeDialog call, got 0".
+        isolate: true,
         fileParallelism: false,
         pool: 'threads',
         coverage: {

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "version": "0.0.0",
     "packageManager": "yarn@4.5.3",
     "devDependencies": {
-        "@cratis/arc": "^20.49.2",
-        "@cratis/arc.react": "^20.49.2",
-        "@cratis/arc.vite": "^20.49.2",
+        "@cratis/arc": "^21.0.2",
+        "@cratis/arc.react": "^21.0.2",
+        "@cratis/arc.vite": "^21.0.2",
         "@eslint/eslintrc": "^3.3.5",
         "@eslint/js": "^10.0.1",
         "@rollup/plugin-node-resolve": "^16.0.3",


### PR DESCRIPTION
## Changed

- The component library now works with Arc 21 as well as Arc 20, so applications are no longer held on the Arc 20 line. This is what Cratis Chronicle 16.18.0 and newer require.

## Fixed

- Specs that mock the same module no longer interfere with each other, which had made dialog-closing specs fail intermittently.