### PR TITLE
Let a dialog choose where initial focus lands

### DIFF
--- a/.ai/rules/dialogs.md
+++ b/.ai/rules/dialogs.md
@@ -140,6 +140,32 @@ import { DialogButtons, DialogResult, useDialogContext } from '@cratis/arc.react
 | `DialogButtons.Ok` | Ok only |
 | `null` | No buttons (content-only dialog) |
 
+A custom `buttons` ReactNode is not just a different footer — the dialog can no longer tell which of your buttons means confirm and which means dismiss, so it also **removes the close (X), stops `Escape` closing the dialog, and never calls `onConfirm` / `onCancel` / `onClose`** (including the confirm handler `CommandDialog` uses to execute its command). A custom footer must close the dialog itself via `useDialogContext().closeDialog(...)`.
+
+## Initial Focus on Destructive Dialogs
+
+`Dialog` (and `CommandDialog`, which forwards it) focuses the confirm button when the dialog opens. A focused native button fires `click` from the **keydown** of `Enter`, so a key still held from the control that opened the dialog — or the ordinary habit of pressing `Enter` twice — confirms it immediately.
+
+A dialog that collects input is protected for free, because `isValid` / `isCommandFormValid` keeps confirm disabled until the form is complete. A dialog that needs **no** input is not — which is backwards when the action is irreversible. Say where focus should go instead:
+
+```tsx
+import { DialogInitialFocus } from '@cratis/components/Dialogs';
+
+<Dialog title="Delete personal data?" buttons={DialogButtons.YesNo}
+        initialFocus={DialogInitialFocus.Cancel}
+        onConfirm={...} onCancel={...}>
+    This permanently removes the person and every record about them.
+</Dialog>
+```
+
+| `DialogInitialFocus` | Focuses |
+|---|---|
+| `Confirm` (default) | The `Ok` / `Yes` button |
+| `Cancel` | The dismissing button — `Cancel`, or `No` when the set has no `Cancel` |
+| `Content` | The dialog's own title, so nothing is armed |
+
+`Cancel` falls back to `Content` when there is no dismissing button. Use `initialFocus` rather than a custom footer for this — it changes focus and nothing else.
+
 ## Customizing Built-in Buttons
 
 Use `okLabel`/`cancelLabel` to rename the buttons, and `isValid` to disable the confirm button:
@@ -213,7 +239,8 @@ Use `buttons={null}` for dialogs that contain their own internal actions (e.g. a
 |---|---|---|
 | `title` | `string` | Header text (replaces PrimeReact `header`) |
 | `visible` | `boolean` | Controls visibility |
-| `buttons` | `DialogButtons \| ReactNode \| null` | Prefer `DialogButtons` enum; `null` for no footer |
+| `buttons` | `DialogButtons \| ReactNode \| null` | Prefer `DialogButtons` enum; `null` for no footer. Anything but a `DialogButtons` value also drops the close (X), `Escape`, and the confirm/cancel callbacks |
+| `initialFocus` | `DialogInitialFocus` | Where focus lands on open — `Confirm` (default), `Cancel`, `Content` |
 | `isValid` | `boolean` | Disables the confirm button when `false` |
 | `okLabel` | `string` | Override the Ok/Confirm button label |
 | `cancelLabel` | `string` | Override the Cancel button label |

--- a/Documentation/CommandDialog/index.md
+++ b/Documentation/CommandDialog/index.md
@@ -104,6 +104,7 @@ function MyComponent() {
 - `cancelLabel`: Custom text for cancel button (default: "Cancel")
 - `yesLabel`, `noLabel`: Labels for `YesNo` and `YesNoCancel` button modes
 - `buttons`: `DialogButtons` value or custom footer content
+- `initialFocus`: Where keyboard focus lands when the dialog opens — forwarded to `Dialog` (see below)
 - `resizable`: Whether dialog can be resized
 - `isValid`: Additional validity gate combined with command form validity
 - `onFieldValidate`: Custom validation function for fields
@@ -134,6 +135,33 @@ Multiple callbacks may fire for the same execution. For example, both `onFailed`
 - If `onConfirm` is not provided, `onClose(DialogResult.Ok)` is used.
 - `onCancel` follows the same behavior as `Dialog` (`true` closes).
 - `onClose` closes unless it returns `false`.
+
+## Destructive Commands and Initial Focus
+
+The confirm button is focused when the dialog opens, and a focused native button
+fires `click` from the `keydown` of `Enter`. A command whose form has required
+fields is protected from a held or double-tapped `Enter` for free, because the
+form's validity keeps confirm disabled until something is filled in. A command
+that takes **no** input — the typical "delete this, permanently" command — has
+no such gate, so its confirm button is armed the instant the dialog appears.
+
+Pass `initialFocus` for those. It is forwarded straight to
+[`Dialog`](../Dialogs/dialog.md#initial-focus) and changes nothing else — the
+footer, the close (X), `Escape`, and the confirm wiring that runs the command
+all stay intact.
+
+```tsx
+import { DialogInitialFocus } from '@cratis/components/Dialogs';
+
+<CommandDialog<DeletePersonalData>
+    command={DeletePersonalData}
+    title="Delete personal data?"
+    okLabel="Delete"
+    initialFocus={DialogInitialFocus.Cancel}
+    onSuccess={() => closeDialog(DialogResult.Ok)}>
+    This cannot be undone.
+</CommandDialog>
+```
 
 ## Busy State
 

--- a/Documentation/Dialogs/dialog.md
+++ b/Documentation/Dialogs/dialog.md
@@ -66,14 +66,70 @@ const MyComponent = () => {
 - `onConfirm`: Callback for confirm actions
 - `onCancel`: Callback for cancel actions
 - `onClose`: Fallback close callback
-- `buttons`: Predefined `DialogButtons` or custom footer content
+- `buttons`: Predefined `DialogButtons` or custom footer content. A custom
+  footer also removes the close (X), stops `Escape` closing the dialog, and
+  leaves `onConfirm` / `onCancel` / `onClose` uncalled — the dialog cannot tell
+  which of your buttons means what, so a custom footer must close the dialog
+  itself through `useDialogContext().closeDialog(...)`
 - `width`: Dialog width
 - `style`: Custom dialog style forwarded to PrimeReact `Dialog`
 - `contentStyle`: Custom content area style forwarded to PrimeReact `Dialog`
 - `resizable`: Enables resize
 - `isValid`: Enables or disables confirm actions
 - `isBusy`: When `true`, disables all buttons and shows a loading spinner on the primary action button
+- `initialFocus`: Where keyboard focus lands when the dialog opens (see below)
 - `okLabel`, `cancelLabel`, `yesLabel`, `noLabel`: Button labels
+
+## Initial focus
+
+By default the confirm button is focused when a dialog opens, which makes the
+common "read it, press Enter" flow cost one keystroke. That default also *arms*
+the confirm button: browsers fire `click` from the `keydown` of `Enter`, so a
+key still held down from the control that opened the dialog — or the ordinary
+habit of pressing `Enter` twice — confirms it immediately.
+
+A dialog with input is protected from this for free, because `isValid` keeps
+confirm disabled until the form is complete. A dialog that needs **no** input
+is not, which is exactly backwards when the action is destructive. Say where
+focus should go with `initialFocus`:
+
+| `DialogInitialFocus` | Focuses |
+|---|---|
+| `Confirm` (default) | The `Ok` / `Yes` button |
+| `Cancel` | The dismissing button — `Cancel`, or `No` when the set has no `Cancel` |
+| `Content` | The dialog's own title, so nothing is armed |
+
+```typescript
+import { Dialog, DialogInitialFocus } from '@cratis/components/Dialogs';
+import { DialogButtons, DialogResult, useDialogContext } from '@cratis/arc.react/dialogs';
+
+const DeletePersonalDataDialog = () => {
+    const { closeDialog } = useDialogContext();
+
+    return (
+        <Dialog
+            title='Delete personal data?'
+            buttons={DialogButtons.YesNo}
+            initialFocus={DialogInitialFocus.Cancel}
+            onConfirm={() => closeDialog(DialogResult.Yes)}
+            onCancel={() => closeDialog(DialogResult.No)}
+        >
+            This permanently removes the person and every record about them.
+        </Dialog>
+    );
+};
+```
+
+`Cancel` falls back to `Content` when the button set has nothing to dismiss
+with (`DialogButtons.Ok`, a custom footer, or no footer). Focus never stays on
+`document.body`: a modal that does not move focus into itself leaves keyboard
+and screen-reader users stranded outside the content that just interrupted
+them.
+
+`initialFocus` is forwarded by `CommandDialog`, and it changes **only** focus —
+the footer, the close (X), `Escape`, and every callback keep working. That is
+the difference from the older workaround of replacing `buttons` with a custom
+node, which silently gives all of those up.
 
 ## Notes
 

--- a/Source/CommandDialog/CommandDialog.stories.tsx
+++ b/Source/CommandDialog/CommandDialog.stories.tsx
@@ -8,6 +8,7 @@ import { Command, CommandResult, CommandValidator } from '@cratis/arc/commands';
 import { PropertyDescriptor } from '@cratis/arc/reflection';
 import { InputTextField, NumberField, TextAreaField } from '../CommandForm/fields';
 import { DialogResult, useDialog, useDialogContext } from '@cratis/arc.react/dialogs';
+import { DialogInitialFocus } from '../Dialogs/DialogInitialFocus';
 import '@cratis/arc/validation';
 
 const meta: Meta<typeof CommandDialog> = {
@@ -845,6 +846,100 @@ export const WithResponseTypeAndCallbacks: Story = {
                     <InputTextField value={(c: CreateUserCommand) => c.email} title="Email" placeholder="Enter email" type="email" />
                     <NumberField value={(c: CreateUserCommand) => c.age} title="Age" placeholder="Enter age (18-120)" />
                 </CommandDialog>
+            </div>
+        );
+    },
+};
+
+/**
+ * A destructive command that needs **no** input. Every other story here is
+ * protected from a held or double-tapped `Enter` for free, because
+ * `isCommandFormValid` keeps the confirm button disabled until its fields are
+ * filled in — but a command with no fields is valid the moment it appears, so
+ * its confirm button is armed on mount.
+ *
+ * `initialFocus` moves the keyboard off it without giving up the footer, the
+ * close (X), `Escape`, or the confirm wiring that runs the command.
+ */
+export const DestructiveCommandFocusesDismiss: Story = {
+    render: () => {
+        const [result, setResult] = useState<string>('');
+
+        class NothingToValidate extends CommandValidator {
+        }
+
+        class DeletePersonalDataCommand extends Command<object> {
+            readonly route: string = '/api/people/delete';
+            readonly validation: CommandValidator = new NothingToValidate();
+            readonly propertyDescriptors: PropertyDescriptor[] = [
+                new PropertyDescriptor('personId', String),
+            ];
+
+            personId = '';
+
+            constructor() {
+                super(Object, false);
+            }
+
+            get requestParameters(): string[] {
+                return [];
+            }
+
+            get properties(): string[] {
+                return ['personId'];
+            }
+
+            override async validate(): Promise<CommandResult<object>> {
+                return CommandResult.empty;
+            }
+
+            override async execute(): Promise<CommandResult<object>> {
+                await new Promise(resolve => setTimeout(resolve, 300));
+                return CommandResult.empty;
+            }
+        }
+
+        const DeletePersonalDataDialog = () => {
+            const { closeDialog } = useDialogContext<CommandResult<object>>();
+
+            return (
+                <CommandDialog<DeletePersonalDataCommand>
+                    command={DeletePersonalDataCommand}
+                    title="Delete personal data?"
+                    okLabel="Delete"
+                    cancelLabel="Keep"
+                    autoServerValidate={false}
+                    initialFocus={DialogInitialFocus.Cancel}
+                    initialValues={{ personId: '8f1b9c1e-0000-4000-8000-000000000000' }}
+                    onSuccess={() => closeDialog(DialogResult.Ok)}
+                    onCancel={() => closeDialog(DialogResult.Cancelled)}
+                >
+                    <p>This permanently removes the person and every record about them. It cannot be undone.</p>
+                </CommandDialog>
+            );
+        };
+
+        const [DeletePersonalDataDialogComponent, showDeletePersonalDataDialog] = useDialog<CommandResult<object>>(DeletePersonalDataDialog);
+
+        return (
+            <div className="storybook-wrapper">
+                <button
+                    className="p-button p-component mb-3"
+                    onClick={async () => {
+                        const [dialogResult] = await showDeletePersonalDataDialog();
+                        setResult(dialogResult === DialogResult.Ok ? 'Deleted' : 'Kept');
+                    }}
+                >
+                    Delete
+                </button>
+
+                {result && (
+                    <div className="p-3 mt-3 bg-green-100 border-round">
+                        <strong>Outcome:</strong> {result}
+                    </div>
+                )}
+
+                <DeletePersonalDataDialogComponent />
             </div>
         );
     },

--- a/Source/CommandDialog/CommandDialog.tsx
+++ b/Source/CommandDialog/CommandDialog.tsx
@@ -57,6 +57,7 @@ const CommandDialogWrapper = <TCommand extends object, TResponse = object>({
     contentStyle,
     resizable,
     buttons,
+    initialFocus,
     okLabel,
     cancelLabel,
     yesLabel,
@@ -82,6 +83,7 @@ const CommandDialogWrapper = <TCommand extends object, TResponse = object>({
     contentStyle?: DialogProps['contentStyle'];
     resizable?: boolean;
     buttons?: DialogProps['buttons'];
+    initialFocus?: DialogProps['initialFocus'];
     okLabel?: string;
     cancelLabel?: string;
     yesLabel?: string;
@@ -176,6 +178,7 @@ const CommandDialogWrapper = <TCommand extends object, TResponse = object>({
             contentStyle={contentStyle}
             resizable={resizable}
             buttons={buttons}
+            initialFocus={initialFocus}
             onClose={onClose}
             onConfirm={handleConfirm}
             onCancel={onCancel}
@@ -230,6 +233,32 @@ const CommandDialogWrapper = <TCommand extends object, TResponse = object>({
  *
  * Throughout, the dialog is in the `isBusy` state — every action button is
  * disabled and the confirm button shows a spinner.
+ *
+ * ## Destructive commands and initial focus
+ *
+ * The confirm button is focused when the dialog opens, and a focused native
+ * button fires `click` from the `keydown` of `Enter`. A command whose form
+ * has required fields is protected from a held or double-tapped `Enter` for
+ * free, because `isCommandFormValid` keeps confirm disabled until something
+ * is filled in. A command that takes **no** input — the typical "delete
+ * this, permanently" command — has no such gate, so its confirm button is
+ * armed the instant the dialog appears.
+ *
+ * Pass `initialFocus` (forwarded straight to {@link Dialog}) for those:
+ *
+ * ```tsx
+ * <CommandDialog<DeletePerson>
+ *     command={DeletePerson}
+ *     title="Delete personal data?"
+ *     okLabel="Delete"
+ *     initialFocus={DialogInitialFocus.Cancel}
+ *     onSuccess={() => closeDialog(DialogResult.Ok)}>
+ *     This cannot be undone.
+ * </CommandDialog>
+ * ```
+ *
+ * Everything else — the footer, the close (X), `Escape`, and the confirm
+ * wiring that runs the command — is untouched.
  *
  * ## Field binding
  *
@@ -296,6 +325,7 @@ const CommandDialogComponent = <TCommand extends object = object, TResponse = ob
         contentStyle,
         resizable,
         buttons = DialogButtons.OkCancel,
+        initialFocus,
         okLabel,
         cancelLabel,
         yesLabel,
@@ -323,6 +353,7 @@ const CommandDialogComponent = <TCommand extends object = object, TResponse = ob
                 contentStyle={contentStyle}
                 resizable={resizable}
                 buttons={buttons}
+                initialFocus={initialFocus}
                 okLabel={okLabel}
                 cancelLabel={cancelLabel}
                 yesLabel={yesLabel}

--- a/Source/CommandDialog/for_CommandDialog/when_initial_focus_is_specified.ts
+++ b/Source/CommandDialog/for_CommandDialog/when_initial_focus_is_specified.ts
@@ -1,0 +1,87 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// @vitest-environment jsdom
+
+import React from 'react';
+import { vi } from 'vitest';
+import { DialogInitialFocus } from '../../Dialogs/DialogInitialFocus';
+import { click, focusedElement, pressEnterOnFocusedElement, render, unmount, type DialogInTheDom } from '../../Dialogs/for_Dialog/given/a_dialog_in_the_dom';
+
+const { executeCommand, succeeded } = vi.hoisted(() => ({
+    executeCommand: vi.fn(async () => ({ isSuccess: true, isValid: true, validationResults: [] })),
+    succeeded: vi.fn()
+}));
+
+vi.mock('@cratis/arc.react/commands', () => ({
+    CommandForm: (props: { children?: React.ReactNode }) =>
+        React.createElement('div', null, props.children),
+    useCommandFormContext: () => ({
+        isValid: true,
+        setCommandValues: () => { /* not part of this scenario */ },
+        setCommandResult: () => { /* not part of this scenario */ }
+    }),
+    useCommandInstance: () => ({ execute: executeCommand }),
+    CommandFormFieldWrapper: (props: { field?: React.ReactNode }) =>
+        React.createElement('div', null, props.field)
+}));
+
+class DeletePersonalData {
+    personId: string = '';
+}
+
+describe('when a command dialog is given an initial focus', () => {
+    let dialog: DialogInTheDom;
+
+    const renderDialog = async (initialFocus?: DialogInitialFocus) => {
+        executeCommand.mockClear();
+        succeeded.mockClear();
+
+        const { CommandDialog } = await import('../CommandDialog');
+
+        dialog = await render(React.createElement(CommandDialog, {
+            command: DeletePersonalData as unknown as new () => object,
+            title: 'Delete personal data',
+            visible: true,
+            initialFocus,
+            onSuccess: succeeded,
+            children: React.createElement('p', null, 'This cannot be undone')
+        }));
+    };
+
+    afterEach(async () => await unmount(dialog));
+
+    it('should focus the Ok button when nothing is specified', async () => {
+        await renderDialog();
+
+        focusedElement().should.equal('button:Ok');
+    });
+
+    it('should forward the choice to the dialog it wraps', async () => {
+        await renderDialog(DialogInitialFocus.Cancel);
+
+        focusedElement().should.equal('button:Cancel');
+    });
+
+    it('should forward a request to focus the content', async () => {
+        await renderDialog(DialogInitialFocus.Content);
+
+        focusedElement().should.equal('span:Delete personal data');
+    });
+
+    it('should not run the command on an Enter that repeats onto the freshly mounted dialog', async () => {
+        await renderDialog(DialogInitialFocus.Cancel);
+
+        await pressEnterOnFocusedElement();
+
+        executeCommand.should.not.have.been.called;
+    });
+
+    it('should still run the command when the user deliberately confirms', async () => {
+        await renderDialog(DialogInitialFocus.Cancel);
+
+        await click('Ok');
+
+        executeCommand.should.have.been.calledOnce;
+        succeeded.should.have.been.calledOnce;
+    });
+});

--- a/Source/Dialogs/BusyIndicatorDialog.tsx
+++ b/Source/Dialogs/BusyIndicatorDialog.tsx
@@ -4,6 +4,7 @@
 import { BusyIndicatorDialogRequest } from '@cratis/arc.react/dialogs';
 import { ProgressSpinner } from 'primereact/progressspinner';
 import { Dialog } from './Dialog';
+import { DialogInitialFocus } from './DialogInitialFocus';
 
 /**
  * Modal "busy" dialog used by the `@cratis/arc.react` dialog host whenever a
@@ -43,7 +44,10 @@ import { Dialog } from './Dialog';
  *
  * - **No interactive buttons.** A busy indicator is a wait-state, not a
  *   confirmation prompt. The dialog has no Ok / Cancel / X — only the host
- *   can dismiss it.
+ *   can dismiss it. Because there is nothing focusable inside it, initial
+ *   focus is put on the dialog's own title, so a keyboard or screen-reader
+ *   user is told what is happening instead of being left on `document.body`
+ *   behind the modal mask.
  * - **No per-instance pass-through.** The request type
  *   ({@link BusyIndicatorDialogRequest}) is owned by `@cratis/arc.react`, so
  *   `pt` / `unstyled` are not exposed on a per-call basis. Restyle the
@@ -59,6 +63,7 @@ export const BusyIndicatorDialog = (props: BusyIndicatorDialogRequest) => {
             visible={true}
             onCancel={() => undefined}
             buttons={null}
+            initialFocus={DialogInitialFocus.Content}
         >
             <div className="flex flex-col items-center justify-center gap-4 py-4">
                 <ProgressSpinner />

--- a/Source/Dialogs/Dialog.stories.tsx
+++ b/Source/Dialogs/Dialog.stories.tsx
@@ -4,6 +4,7 @@
 import React, { useState } from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { Dialog } from './Dialog';
+import { DialogInitialFocus } from './DialogInitialFocus';
 import { DialogButtons, DialogResult, useDialog, useDialogContext } from '@cratis/arc.react/dialogs';
 import { Button } from 'primereact/button';
 import { InputText } from 'primereact/inputtext';
@@ -19,7 +20,7 @@ const meta: Meta<typeof Dialog> = {
 export default meta;
 type Story = StoryObj<typeof Dialog>;
 
-const DialogWrapper = ({ buttons, title, children, isValid }: { buttons: DialogButtons; title: string; children: React.ReactNode; isValid?: boolean }) => {
+const DialogWrapper = ({ buttons, title, children, isValid, initialFocus }: { buttons: DialogButtons; title: string; children: React.ReactNode; isValid?: boolean; initialFocus?: DialogInitialFocus }) => {
     const ResultDialog = () => {
         const { closeDialog } = useDialogContext();
 
@@ -27,6 +28,7 @@ const DialogWrapper = ({ buttons, title, children, isValid }: { buttons: DialogB
             <Dialog
                 title={title}
                 buttons={buttons}
+                initialFocus={initialFocus}
                 onConfirm={() => closeDialog(DialogResult.Ok)}
                 onCancel={() => closeDialog(DialogResult.Cancelled)}
                 isValid={isValid}
@@ -74,6 +76,33 @@ export const Ok: Story = {
     render: () => (
         <DialogWrapper title="Information" buttons={DialogButtons.Ok}>
             <p>The operation completed successfully.</p>
+        </DialogWrapper>
+    )
+};
+
+/**
+ * A destructive dialog that needs no input. Initial focus is put on the
+ * dismissing button, so the `Enter` still held down from the row that opened
+ * the dialog — or a reflexive second press — cannot confirm it. Hold `Enter`
+ * on the trigger button to see the difference against the stories above.
+ */
+export const DestructiveFocusesDismiss: Story = {
+    render: () => (
+        <DialogWrapper title="Delete personal data?" buttons={DialogButtons.YesNo} initialFocus={DialogInitialFocus.Cancel}>
+            <p>This permanently removes the person and every record about them. It cannot be undone.</p>
+        </DialogWrapper>
+    )
+};
+
+/**
+ * Nothing is armed at all: focus goes to the dialog's own title, so screen
+ * readers announce the dialog from the top and the first `Tab` walks the
+ * content. Use it when the dialog should be read before it is answered.
+ */
+export const DestructiveArmsNothing: Story = {
+    render: () => (
+        <DialogWrapper title="Delete personal data?" buttons={DialogButtons.OkCancel} initialFocus={DialogInitialFocus.Content}>
+            <p>This permanently removes the person and every record about them. It cannot be undone.</p>
         </DialogWrapper>
     )
 };

--- a/Source/Dialogs/Dialog.tsx
+++ b/Source/Dialogs/Dialog.tsx
@@ -4,7 +4,8 @@
 import { Dialog as PrimeDialog, type DialogProps as PrimeDialogProps } from 'primereact/dialog';
 import { Button } from 'primereact/button';
 import { DialogResult, DialogButtons, useDialogContext } from '@cratis/arc.react/dialogs';
-import { ReactNode } from 'react';
+import { ReactNode, useRef } from 'react';
+import { DialogInitialFocus } from './DialogInitialFocus';
 
 /**
  * Callback used by {@link Dialog} (and its wrappers) when the dialog is about to
@@ -54,8 +55,33 @@ export interface DialogProps {
      * the predefined sets (`Ok`, `OkCancel`, `YesNo`, `YesNoCancel`), `null` for
      * no footer, or a custom React node to fully render your own footer.
      * Defaults to `DialogButtons.OkCancel`.
+     *
+     * ⚠️ **Anything other than a {@link DialogButtons} value also opts the dialog
+     * out of three unrelated behaviors**, because the dialog can no longer know
+     * which of your buttons means "confirm" and which means "dismiss":
+     * the header close (X) is removed, `Escape` no longer closes, and
+     * `onClose` / `onCancel` / `onConfirm` are never invoked — including the
+     * confirm handler that {@link CommandDialog} uses to execute its command.
+     * A custom footer must therefore close the dialog itself through
+     * `useDialogContext().closeDialog(...)`.
+     *
+     * Reach for {@link initialFocus} rather than a custom footer when all you
+     * want is to change which button starts out focused.
      */
     buttons?: DialogButtons | ReactNode;
+
+    /**
+     * Where keyboard focus lands when the dialog becomes visible. Defaults to
+     * {@link DialogInitialFocus.Confirm}, which focuses the `Ok` / `Yes` button.
+     *
+     * Set it to {@link DialogInitialFocus.Cancel} or
+     * {@link DialogInitialFocus.Content} for a dialog whose confirm action is
+     * destructive and needs no input to become valid — otherwise the confirm
+     * button sits armed under the same `Enter` that opened the dialog, and key
+     * auto-repeat (or the habit of pressing `Enter` twice) collapses a two-step
+     * confirmation into one.
+     */
+    initialFocus?: DialogInitialFocus;
 
     /** Dialog body content. */
     children: ReactNode;
@@ -144,6 +170,36 @@ export interface DialogProps {
  * - **Validity gate** (`isValid`) that disables the confirm button without
  *   disabling the cancel button. Used by command-executing wrappers to
  *   block submission while form validation fails.
+ * - **Initial focus** (`initialFocus`) choosing which element inside the
+ *   dialog the keyboard lands on when it opens.
+ *
+ * ## Initial focus
+ *
+ * By default the confirm button is focused when the dialog opens, so the
+ * common "read it, press Enter" flow costs one keystroke. That default also
+ * *arms* the confirm button: browsers fire `click` from the `keydown` of
+ * `Enter`, so the key still held down from opening the dialog — or the very
+ * ordinary habit of pressing `Enter` twice — confirms it immediately.
+ *
+ * A dialog whose confirm action is destructive **and** needs no input to
+ * become valid gets no protection from `isValid`, because there is nothing
+ * to fill in. Give those dialogs an explicit
+ * {@link DialogInitialFocus} instead:
+ *
+ * ```tsx
+ * <Dialog title="Delete personal data?"
+ *         buttons={DialogButtons.YesNo}
+ *         initialFocus={DialogInitialFocus.Cancel}
+ *         onConfirm={...} onCancel={...}>
+ *     This permanently removes the person and every record about them.
+ * </Dialog>
+ * ```
+ *
+ * `Cancel` focuses the dismissing button (`Cancel`, or `No` when the set has
+ * no `Cancel`); `Content` focuses the dialog's title so nothing at all is
+ * armed and screen readers announce the dialog from the top. Both keep the
+ * footer, the close (X), `Escape`, and every callback intact — unlike
+ * replacing `buttons` with a custom node.
  *
  * ## Arc dialog host integration
  *
@@ -203,6 +259,7 @@ export const Dialog = ({
     onConfirm,
     onCancel,
     buttons = DialogButtons.OkCancel,
+    initialFocus = DialogInitialFocus.Confirm,
     children,
     width = '450px',
     style,
@@ -231,9 +288,35 @@ export const Dialog = ({
     }
     
     const isDialogValid = isValid !== false;
+
+    // A dismissing button only exists for the predefined sets that have one — Cancel for
+    // OkCancel / YesNoCancel, No for YesNo. Asking for Cancel focus without one (DialogButtons.Ok,
+    // a custom footer node, or no footer) degrades to focusing the title rather than silently
+    // leaving focus on document.body outside the modal.
+    const hasDismissingButton = typeof buttons === 'number' && buttons !== DialogButtons.Ok;
+    const resolvedInitialFocus = (initialFocus === DialogInitialFocus.Cancel && !hasDismissingButton)
+        ? DialogInitialFocus.Content
+        : initialFocus;
+
+    const focusesConfirmButton = resolvedInitialFocus === DialogInitialFocus.Confirm;
+    const focusesDismissingButton = resolvedInitialFocus === DialogInitialFocus.Cancel;
+    const focusesTitle = resolvedInitialFocus === DialogInitialFocus.Content;
+
+    // PrimeReact's focus trap parks focus on the first focusable element inside the dialog while
+    // it transitions in, and its own onShow focus only fires when nothing in the dialog has focus.
+    // Moving focus to the title from onShow therefore runs last and wins, without having to fight
+    // the trap or turn focusOnShow off (which would leave focus outside the modal for the duration
+    // of the transition).
+    const titleRef = useRef<HTMLSpanElement>(null);
+    const handleShow = () => {
+        if (focusesTitle) {
+            titleRef.current?.focus({ preventScroll: true });
+        }
+    };
+
     const headerElement = (
         <div className="inline-flex items-center justify-center gap-2">
-            <span className="font-bold whitespace-nowrap">{title}</span>
+            <span ref={titleRef} tabIndex={focusesTitle ? -1 : undefined} className="font-bold whitespace-nowrap">{title}</span>
         </div>
     );
 
@@ -265,29 +348,29 @@ export const Dialog = ({
 
     const okFooter = (
         <>
-            <Button label={okLabel} icon="pi pi-check" onClick={() => handleClose(DialogResult.Ok)} disabled={!isDialogValid || isBusy} loading={isBusy} autoFocus />
+            <Button label={okLabel} icon="pi pi-check" onClick={() => handleClose(DialogResult.Ok)} disabled={!isDialogValid || isBusy} loading={isBusy} autoFocus={focusesConfirmButton} />
         </>
     );
 
     const okCancelFooter = (
         <>
-            <Button label={okLabel} icon="pi pi-check" onClick={() => handleClose(DialogResult.Ok)} disabled={!isDialogValid || isBusy} loading={isBusy} autoFocus />
-            <Button label={cancelLabel} icon="pi pi-times" outlined onClick={() => handleClose(DialogResult.Cancelled)} disabled={isBusy} />
+            <Button label={okLabel} icon="pi pi-check" onClick={() => handleClose(DialogResult.Ok)} disabled={!isDialogValid || isBusy} loading={isBusy} autoFocus={focusesConfirmButton} />
+            <Button label={cancelLabel} icon="pi pi-times" outlined onClick={() => handleClose(DialogResult.Cancelled)} disabled={isBusy} autoFocus={focusesDismissingButton} />
         </>
     );
 
     const yesNoFooter = (
         <>
-            <Button label={yesLabel} icon="pi pi-check" onClick={() => handleClose(DialogResult.Yes)} disabled={!isDialogValid || isBusy} loading={isBusy} autoFocus />
-            <Button label={noLabel} icon="pi pi-times" outlined onClick={() => handleClose(DialogResult.No)} disabled={isBusy} />
+            <Button label={yesLabel} icon="pi pi-check" onClick={() => handleClose(DialogResult.Yes)} disabled={!isDialogValid || isBusy} loading={isBusy} autoFocus={focusesConfirmButton} />
+            <Button label={noLabel} icon="pi pi-times" outlined onClick={() => handleClose(DialogResult.No)} disabled={isBusy} autoFocus={focusesDismissingButton} />
         </>
     );
 
     const yesNoCancelFooter = (
         <>
-            <Button label={yesLabel} icon="pi pi-check" onClick={() => handleClose(DialogResult.Yes)} disabled={!isDialogValid || isBusy} loading={isBusy} autoFocus />
+            <Button label={yesLabel} icon="pi pi-check" onClick={() => handleClose(DialogResult.Yes)} disabled={!isDialogValid || isBusy} loading={isBusy} autoFocus={focusesConfirmButton} />
             <Button label={noLabel} icon="pi pi-times" outlined onClick={() => handleClose(DialogResult.No)} disabled={isBusy} />
-            <Button label={cancelLabel} icon="pi pi-times" outlined onClick={() => handleClose(DialogResult.Cancelled)} disabled={isBusy} />
+            <Button label={cancelLabel} icon="pi pi-times" outlined onClick={() => handleClose(DialogResult.Cancelled)} disabled={isBusy} autoFocus={focusesDismissingButton} />
         </>
     );
 
@@ -325,6 +408,7 @@ export const Dialog = ({
             footer={footer}
             // eslint-disable-next-line @typescript-eslint/no-empty-function
             onHide={typeof buttons === 'number' ? () => handleClose(DialogResult.Cancelled) : () => {}}
+            onShow={handleShow}
             visible={visible}
             style={{ width, ...style }}
             contentStyle={contentStyle}

--- a/Source/Dialogs/DialogInitialFocus.ts
+++ b/Source/Dialogs/DialogInitialFocus.ts
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+ * Defines where keyboard focus lands when a dialog becomes visible.
+ *
+ * A modal must move focus into itself when it opens — leaving focus on
+ * `document.body` strands keyboard and screen-reader users outside the
+ * content they were just interrupted with. Every member of this enum
+ * therefore names a real element inside the dialog; there is deliberately
+ * no "focus nothing" member.
+ */
+export enum DialogInitialFocus {
+
+    /**
+     * Focus the confirming button (`Ok` / `Yes`). This is the default and
+     * the fastest path for a dialog whose expected answer is "go ahead".
+     *
+     * ⚠️ It also *arms* that button: a browser fires `click` on a native
+     * button from the `keydown` of `Enter` or `Space`, so a held key or a
+     * second press of the key that opened the dialog confirms it. For a
+     * destructive action that needs no input to become valid, prefer
+     * {@link DialogInitialFocus.Cancel} or {@link DialogInitialFocus.Content}.
+     */
+    Confirm = 1,
+
+    /**
+     * Focus the dismissing button — `Cancel` when the button set has one,
+     * otherwise `No`. This is the least destructive action, which is what
+     * the WAI-ARIA authoring practices recommend focusing for a dialog that
+     * confirms something irreversible.
+     *
+     * Falls back to {@link DialogInitialFocus.Content} when the button set
+     * has no dismissing button (`DialogButtons.Ok`), when the footer is a
+     * custom `ReactNode`, or when there is no footer at all.
+     */
+    Cancel = 2,
+
+    /**
+     * Focus the dialog's own title instead of any button, so nothing is
+     * armed. Screen readers announce the dialog and its title, and the
+     * first `Tab` walks the content from the top.
+     *
+     * This is the right choice for a dialog that should be *read* before it
+     * is answered, and the only sensible choice for a dialog with no footer
+     * buttons at all.
+     */
+    Content = 3
+}

--- a/Source/Dialogs/for_BusyIndicatorDialog/when_shown.ts
+++ b/Source/Dialogs/for_BusyIndicatorDialog/when_shown.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// @vitest-environment jsdom
+
+import React from 'react';
+import { BusyIndicatorDialog } from '../BusyIndicatorDialog';
+import { focusIsInsideTheDialog, focusedElement, render, unmount, type DialogInTheDom } from '../for_Dialog/given/a_dialog_in_the_dom';
+
+/**
+ * A busy indicator has no buttons at all, so there is nothing for the browser
+ * to focus and focus used to stay on `document.body` — outside the modal it is
+ * blocked by, which leaves a keyboard or screen-reader user with nothing.
+ */
+describe('when a busy indicator dialog is shown', () => {
+    let dialog: DialogInTheDom;
+
+    beforeEach(async () => {
+        dialog = await render(React.createElement(BusyIndicatorDialog, {
+            title: 'Saving',
+            message: 'Persisting your changes'
+        }));
+    });
+
+    afterEach(async () => await unmount(dialog));
+
+    it('should move focus into the dialog', () => {
+        focusIsInsideTheDialog().should.be.true;
+    });
+
+    it('should focus the title so the wait state is announced', () => {
+        focusedElement().should.equal('span:Saving');
+    });
+});

--- a/Source/Dialogs/for_Dialog/given/a_dialog_in_the_dom.ts
+++ b/Source/Dialogs/for_Dialog/given/a_dialog_in_the_dom.ts
@@ -1,0 +1,133 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+/**
+ * A dialog mounted into a real document, together with what is needed to take
+ * it down again. Initial focus only exists in a DOM, so the specs covering it
+ * render for real rather than to static markup.
+ */
+export interface DialogInTheDom {
+    container: HTMLDivElement;
+    root: Root;
+}
+
+/**
+ * Renders an element into a real document and lets PrimeReact's show
+ * transition complete, so the dialog has settled on its initial focus by the
+ * time the spec looks at it.
+ * @param element - The element to render.
+ * @returns The mounted dialog, to be passed to {@link unmount}.
+ */
+export const render = async (element: React.ReactElement): Promise<DialogInTheDom> => {
+    (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+        root.render(element);
+    });
+
+    await act(async () => {
+        await new Promise(resolve => setTimeout(resolve, 400));
+    });
+
+    return { container, root };
+};
+
+/**
+ * Unmounts a dialog rendered with {@link render} and removes its container.
+ * @param dialog - The mounted dialog.
+ */
+export const unmount = async (dialog: DialogInTheDom) => {
+    await act(async () => {
+        dialog.root.unmount();
+    });
+    dialog.container.remove();
+};
+
+/**
+ * Describes what currently has keyboard focus as a plain string, so specs can
+ * assert on it directly. Elements come from the jsdom realm and therefore do
+ * not carry chai's `should`, and a description also makes a failure say what
+ * was focused instead of only that two objects differ.
+ *
+ * Reads as `button:Ok`, `span:Delete personal data`, or `document.body` when
+ * focus was never moved into the dialog at all.
+ * @returns The description of the focused element.
+ */
+export const focusedElement = (): string => {
+    const element = document.activeElement as HTMLElement | null;
+    if (!element || element === document.body) {
+        return 'document.body';
+    }
+    const label = element.getAttribute('aria-label') ?? element.textContent ?? '';
+    return `${element.tagName.toLowerCase()}:${label}`;
+};
+
+/**
+ * Whether focus currently sits inside the dialog rather than outside it.
+ * @returns True when the focused element is inside the dialog.
+ */
+export const focusIsInsideTheDialog = (): boolean => {
+    const dialog = document.querySelector('[role="dialog"]');
+    return !!dialog && dialog.contains(document.activeElement) && document.activeElement !== document.body;
+};
+
+/**
+ * Whether the dialog renders its header close (X) button.
+ * @returns True when the close button is present.
+ */
+export const hasCloseButton = (): boolean => !!document.querySelector('.p-dialog-header-close');
+
+/**
+ * The `tabindex` attribute on the dialog's title, or `'none'` when it has none.
+ * @returns The tab index as a string.
+ */
+export const titleTabIndex = (): string =>
+    document.querySelector('.p-dialog-title span')?.getAttribute('tabindex') ?? 'none';
+
+const buttonLabeled = (label: string) =>
+    Array.from(document.querySelectorAll('button')).find(button => button.textContent === label);
+
+/**
+ * Presses `Enter` on whatever has focus, the way a browser does: the key event
+ * goes to the focused element, and a focused native button additionally gets
+ * the `click` the browser synthesizes from the key *down*. `repeat` is set
+ * because the case that matters is a key still held from before the dialog
+ * existed.
+ */
+export const pressEnterOnFocusedElement = async () => {
+    const element = document.activeElement as HTMLElement;
+
+    await act(async () => {
+        element.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', repeat: true, bubbles: true }));
+        if (element instanceof HTMLButtonElement) {
+            element.click();
+        }
+    });
+};
+
+/**
+ * Presses `Escape`, which PrimeReact listens for on the document.
+ */
+export const pressEscape = async () => {
+    await act(async () => {
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', code: 'Escape', bubbles: true }));
+    });
+};
+
+/**
+ * Clicks a button by its visible label.
+ * @param label - The label of the button to click.
+ */
+export const click = async (label: string) => {
+    await act(async () => {
+        buttonLabeled(label)?.click();
+    });
+};

--- a/Source/Dialogs/for_Dialog/when_choosing_initial_focus_over_a_custom_footer.ts
+++ b/Source/Dialogs/for_Dialog/when_choosing_initial_focus_over_a_custom_footer.ts
@@ -1,0 +1,86 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// @vitest-environment jsdom
+
+import React from 'react';
+import { DialogButtons } from '@cratis/arc.react/dialogs';
+import { Dialog } from '../Dialog';
+import { DialogInitialFocus } from '../DialogInitialFocus';
+import { click, hasCloseButton, pressEscape, render, unmount, type DialogInTheDom } from './given/a_dialog_in_the_dom';
+
+/**
+ * Before `initialFocus` existed, the only way to stop the confirm button being
+ * armed was to replace the footer with a custom node — which silently takes the
+ * close (X), `Escape` and every confirm/cancel callback away with it, because
+ * the dialog can no longer tell which of the caller's buttons means what.
+ *
+ * These specs pin both halves: what `initialFocus` keeps, and what the old
+ * workaround costs.
+ */
+describe('when choosing initial focus over a custom footer', () => {
+    let dialog: DialogInTheDom;
+    let confirmed: number;
+    let cancelled: number;
+
+    const renderDialog = async (buttons: DialogButtons | React.ReactNode, initialFocus?: DialogInitialFocus) => {
+        confirmed = 0;
+        cancelled = 0;
+        dialog = await render(React.createElement(Dialog, {
+            title: 'Delete personal data',
+            visible: true,
+            buttons,
+            initialFocus,
+            onConfirm: () => { confirmed++; return true; },
+            onCancel: () => { cancelled++; return true; },
+            children: React.createElement('p', null, 'This cannot be undone')
+        }));
+    };
+
+    const aCustomFooter = () => React.createElement('button', { type: 'button' }, 'Delete');
+
+    afterEach(async () => await unmount(dialog));
+
+    it('should keep the close button when initial focus is moved off the confirm button', async () => {
+        await renderDialog(DialogButtons.OkCancel, DialogInitialFocus.Cancel);
+
+        hasCloseButton().should.be.true;
+    });
+
+    it('should keep Escape closing the dialog when initial focus is moved off the confirm button', async () => {
+        await renderDialog(DialogButtons.OkCancel, DialogInitialFocus.Cancel);
+
+        await pressEscape();
+
+        cancelled.should.equal(1);
+    });
+
+    it('should keep the confirm callback wired when initial focus is moved off the confirm button', async () => {
+        await renderDialog(DialogButtons.OkCancel, DialogInitialFocus.Cancel);
+
+        await click('Ok');
+
+        confirmed.should.equal(1);
+    });
+
+    it('should lose the close button when the footer is replaced instead', async () => {
+        await renderDialog(aCustomFooter());
+
+        hasCloseButton().should.be.false;
+    });
+
+    it('should lose Escape when the footer is replaced instead', async () => {
+        await renderDialog(aCustomFooter());
+
+        await pressEscape();
+
+        cancelled.should.equal(0);
+    });
+
+    it('should lose the confirm callback when the footer is replaced instead', async () => {
+        await renderDialog(aCustomFooter());
+
+        await click('Delete');
+
+        confirmed.should.equal(0);
+    });
+});

--- a/Source/Dialogs/for_Dialog/when_initial_focus_is_cancel.ts
+++ b/Source/Dialogs/for_Dialog/when_initial_focus_is_cancel.ts
@@ -1,0 +1,76 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// @vitest-environment jsdom
+
+import React from 'react';
+import { DialogButtons } from '@cratis/arc.react/dialogs';
+import { Dialog } from '../Dialog';
+import { DialogInitialFocus } from '../DialogInitialFocus';
+import { focusIsInsideTheDialog, focusedElement, pressEnterOnFocusedElement, render, unmount, type DialogInTheDom } from './given/a_dialog_in_the_dom';
+
+describe('when initial focus is cancel', () => {
+    let dialog: DialogInTheDom;
+    let confirmed: number;
+    let cancelled: number;
+
+    const renderDialog = async (buttons: DialogButtons | React.ReactNode) => {
+        confirmed = 0;
+        cancelled = 0;
+        dialog = await render(React.createElement(Dialog, {
+            title: 'Delete personal data',
+            visible: true,
+            buttons,
+            initialFocus: DialogInitialFocus.Cancel,
+            onConfirm: () => { confirmed++; return true; },
+            onCancel: () => { cancelled++; return true; },
+            children: React.createElement('p', null, 'This cannot be undone')
+        }));
+    };
+
+    afterEach(async () => await unmount(dialog));
+
+    it('should focus the Cancel button of an Ok/Cancel dialog', async () => {
+        await renderDialog(DialogButtons.OkCancel);
+
+        focusedElement().should.equal('button:Cancel');
+    });
+
+    it('should focus the No button of a Yes/No dialog', async () => {
+        await renderDialog(DialogButtons.YesNo);
+
+        focusedElement().should.equal('button:No');
+    });
+
+    it('should focus the Cancel button of a Yes/No/Cancel dialog', async () => {
+        await renderDialog(DialogButtons.YesNoCancel);
+
+        focusedElement().should.equal('button:Cancel');
+    });
+
+    it('should fall back to the title when the button set has nothing to dismiss with', async () => {
+        await renderDialog(DialogButtons.Ok);
+
+        focusedElement().should.equal('span:Delete personal data');
+    });
+
+    it('should fall back to the title when the footer is a custom node', async () => {
+        await renderDialog(React.createElement('button', { type: 'button' }, 'Delete'));
+
+        focusedElement().should.equal('span:Delete personal data');
+    });
+
+    it('should keep focus inside the dialog rather than on the document body', async () => {
+        await renderDialog(DialogButtons.Ok);
+
+        focusIsInsideTheDialog().should.be.true;
+    });
+
+    it('should dismiss rather than confirm on an Enter that repeats onto the freshly mounted dialog', async () => {
+        await renderDialog(DialogButtons.OkCancel);
+
+        await pressEnterOnFocusedElement();
+
+        confirmed.should.equal(0);
+        cancelled.should.equal(1);
+    });
+});

--- a/Source/Dialogs/for_Dialog/when_initial_focus_is_content.ts
+++ b/Source/Dialogs/for_Dialog/when_initial_focus_is_content.ts
@@ -1,0 +1,59 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// @vitest-environment jsdom
+
+import React from 'react';
+import { DialogButtons } from '@cratis/arc.react/dialogs';
+import { Dialog } from '../Dialog';
+import { DialogInitialFocus } from '../DialogInitialFocus';
+import { focusIsInsideTheDialog, focusedElement, pressEnterOnFocusedElement, render, titleTabIndex, unmount, type DialogInTheDom } from './given/a_dialog_in_the_dom';
+
+describe('when initial focus is content', () => {
+    let dialog: DialogInTheDom;
+    let confirmed: number;
+    let cancelled: number;
+
+    const renderDialog = async (buttons: DialogButtons | React.ReactNode) => {
+        confirmed = 0;
+        cancelled = 0;
+        dialog = await render(React.createElement(Dialog, {
+            title: 'Delete personal data',
+            visible: true,
+            buttons,
+            initialFocus: DialogInitialFocus.Content,
+            onConfirm: () => { confirmed++; return true; },
+            onCancel: () => { cancelled++; return true; },
+            children: React.createElement('p', null, 'This cannot be undone')
+        }));
+    };
+
+    afterEach(async () => await unmount(dialog));
+
+    it('should focus the title rather than any button', async () => {
+        await renderDialog(DialogButtons.OkCancel);
+
+        focusedElement().should.equal('span:Delete personal data');
+    });
+
+    it('should make the title focusable without putting it in the tab order', async () => {
+        await renderDialog(DialogButtons.OkCancel);
+
+        titleTabIndex().should.equal('-1');
+    });
+
+    it('should move focus into a dialog that has no focusable content at all', async () => {
+        await renderDialog(null);
+
+        focusedElement().should.equal('span:Delete personal data');
+        focusIsInsideTheDialog().should.be.true;
+    });
+
+    it('should arm nothing, so an Enter that repeats onto the dialog does nothing', async () => {
+        await renderDialog(DialogButtons.OkCancel);
+
+        await pressEnterOnFocusedElement();
+
+        confirmed.should.equal(0);
+        cancelled.should.equal(0);
+    });
+});

--- a/Source/Dialogs/for_Dialog/when_initial_focus_is_not_specified.ts
+++ b/Source/Dialogs/for_Dialog/when_initial_focus_is_not_specified.ts
@@ -1,0 +1,73 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// @vitest-environment jsdom
+
+import React from 'react';
+import { DialogButtons } from '@cratis/arc.react/dialogs';
+import { Dialog } from '../Dialog';
+import { focusedElement, pressEnterOnFocusedElement, render, titleTabIndex, unmount, type DialogInTheDom } from './given/a_dialog_in_the_dom';
+
+/**
+ * The regression guard for the whole `initialFocus` feature: a dialog that does
+ * not ask for anything must behave exactly as it did before the prop existed —
+ * confirm button focused, and armed.
+ */
+describe('when initial focus is not specified', () => {
+    let dialog: DialogInTheDom;
+    let confirmed: number;
+    let cancelled: number;
+
+    const renderDialog = async (buttons: DialogButtons) => {
+        confirmed = 0;
+        cancelled = 0;
+        dialog = await render(React.createElement(Dialog, {
+            title: 'Delete personal data',
+            visible: true,
+            buttons,
+            onConfirm: () => { confirmed++; return true; },
+            onCancel: () => { cancelled++; return true; },
+            children: React.createElement('p', null, 'This cannot be undone')
+        }));
+    };
+
+    afterEach(async () => await unmount(dialog));
+
+    it('should focus the Ok button of an Ok/Cancel dialog', async () => {
+        await renderDialog(DialogButtons.OkCancel);
+
+        focusedElement().should.equal('button:Ok');
+    });
+
+    it('should focus the Ok button of an Ok-only dialog', async () => {
+        await renderDialog(DialogButtons.Ok);
+
+        focusedElement().should.equal('button:Ok');
+    });
+
+    it('should focus the Yes button of a Yes/No dialog', async () => {
+        await renderDialog(DialogButtons.YesNo);
+
+        focusedElement().should.equal('button:Yes');
+    });
+
+    it('should focus the Yes button of a Yes/No/Cancel dialog', async () => {
+        await renderDialog(DialogButtons.YesNoCancel);
+
+        focusedElement().should.equal('button:Yes');
+    });
+
+    it('should leave the title unfocusable', async () => {
+        await renderDialog(DialogButtons.OkCancel);
+
+        titleTabIndex().should.equal('none');
+    });
+
+    it('should confirm on an Enter that repeats onto the freshly mounted dialog', async () => {
+        await renderDialog(DialogButtons.OkCancel);
+
+        await pressEnterOnFocusedElement();
+
+        confirmed.should.equal(1);
+        cancelled.should.equal(0);
+    });
+});

--- a/Source/Dialogs/index.ts
+++ b/Source/Dialogs/index.ts
@@ -4,3 +4,4 @@
 export * from './BusyIndicatorDialog';
 export * from './ConfirmationDialog';
 export * from './Dialog';
+export * from './DialogInitialFocus';

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
         "eslint-plugin-react": "^7.37.5",
         "glob": "^13.0.6",
         "globals": "^17.7.0",
+        "jsdom": "^30.0.1",
         "mocha": "^11.7.6",
         "module-alias": "^2.3.4",
         "npm-check-updates": "^22.2.9",


### PR DESCRIPTION
# Summary

A destructive dialog could not stop its OK button taking focus on open without discarding the footer's behavior.

## Added

- `initialFocus` on `Dialog`, forwarded by `CommandDialog`, choosing where focus lands when the dialog opens: `DialogInitialFocus.Confirm` (the default, unchanged), `Cancel`, or `Content`. `Cancel` degrades to `Content` where no dismissing button exists.

## Fixed

- A dialog with a custom footer or `buttons={null}` left focus on `document.body`, outside the modal. `BusyIndicatorDialog` shipped in that state; focus now moves to the dialog's title.
