### PR TITLE
Document CommandForm field support for query-populated initial values

### DIFF
--- a/Documentation/CommandForm/index.md
+++ b/Documentation/CommandForm/index.md
@@ -48,3 +48,26 @@ import { InputTextField, NumberField, CheckboxField } from '@cratis/components/C
     <CheckboxField<MyCommand> value={c => c.active} label="Active" />
 </CommandDialog>
 ```
+
+## Populating Initial Values from a Query
+
+Every field here is built with `asCommandFormField` from `@cratis/arc.react/commands`, so each one automatically supports `CommandForm`'s `populateFromQuery`/`populateFromObservableQuery` props - the form fetches a single-instance query itself and seeds its fields from the result, matched onto the command by property name:
+
+```tsx
+import { CommandForm } from '@cratis/arc.react/commands';
+import { InputTextField } from '@cratis/components/CommandForm';
+import { GetUserProfile } from './queries';
+import { UpdateProfile } from './commands';
+
+<CommandForm command={UpdateProfile} populateFromQuery={GetUserProfile} populateFromQueryArgs={{ userId }}>
+    <InputTextField<UpdateProfile> value={c => c.firstName} title="First name" />
+    <InputTextField<UpdateProfile> value={c => c.lastName} title="Last name" />
+</CommandForm>
+```
+
+Two field props refine this per field - both work on every field type in this package, since they come from the shared `asCommandFormField` wrapper:
+
+- `noInitialValue` - skip this field entirely, even if the query result has a same-named property.
+- `initialValue` - override how the field's value is derived from the query result, either a property accessor matched by name or a function composing a value from the whole result.
+
+See Arc's [Populating a Form from a Query](https://github.com/Cratis/Arc/blob/main/Documentation/frontend/react/command-form/data-loading.md) for the full behavior, including how the populated data becomes the form's change-tracking baseline.


### PR DESCRIPTION
## Documentation

- Documents that every field in this package (built with `asCommandFormField` from `@cratis/arc.react/commands`) already supports Arc's new `populateFromQuery`/`populateFromObservableQuery` `CommandForm` props and the per-field `noInitialValue`/`initialValue` overrides (Cratis/Arc#2549), with a Components-specific usage example in `Documentation/CommandForm/index.md`.

(#133)

## Investigation notes for reviewers

No field component needed a code change. Every field here (`InputTextField.tsx` and siblings) is a thin `asCommandFormField(...)` wrapper with no logic of its own around initial values - the new props land on the shared `BaseCommandFormFieldProps` in Arc.React and flow through to every field automatically. Verified directly against the compiled type declarations of the currently-published `@cratis/arc.react@21.16.0` (`noInitialValue` is present in `asCommandFormField.d.ts`) rather than assuming it.

No `package.json`/lockfile change is included or needed: both `package.json` (root, `^21.0.2`) and `Source/package.json` (`>=20.3.1 <22`) already permit `21.16.0`, and this repo's `yarn.lock` is git-ignored, so a fresh install already resolves the latest compatible version without any manifest change.

**Found, but explicitly out of scope for this PR - flagging for visibility:** resolving `@cratis/arc.react` to any version newer than `21.0.2` (including today's latest, `21.16.0`) currently breaks `DataTables/DataTableForObservableQuery.tsx`'s typecheck:

\`\`\`
error TS2345: Argument of type 'Constructor<TQuery>' is not assignable to parameter of type 'Constructor<IObservableQueryFor<unknown, object>>'.
  ...types returned by 'subscribe(...)' are incompatible... 'ObservableQuerySubscription<TDataType>' is not assignable to 'ObservableQuerySubscription<unknown>' - separate declarations of a private property '_connection'.
\`\`\`

Confirmed pre-existing and unrelated to Arc#2549 specifically - it reproduces identically pinned to `21.15.0` (the version immediately before #2549 merged), so it's a breaking type change somewhere else across the `21.0.2` → `21.16.0` range Components hasn't caught up with. Since this repo has no committed lockfile, the very next fresh install anyone does will hit this. Worth a dedicated follow-up issue rather than folding an unrelated fix into this one.