### PR TITLE
Add AutoCommandForm to generate fields from command properties

### DIFF
--- a/Documentation/CommandForm/auto-command-form.md
+++ b/Documentation/CommandForm/auto-command-form.md
@@ -1,0 +1,47 @@
+# AutoCommandForm
+
+`AutoCommandForm` generates its field list from the command's own properties instead of you writing one field per property by hand. Each property's type picks its field component through a registry - `string` gets `InputTextField`, `number` gets `NumberField`, `boolean` gets `CheckboxField`, `Date` gets `CalendarField` - the same components you would otherwise use directly.
+
+## Usage
+
+```tsx
+import { CommandDialog } from '@cratis/components/CommandDialog';
+import { AutoCommandForm } from '@cratis/components/CommandForm';
+
+<CommandDialog command={RegisterProject} visible={visible} onCancel={() => setVisible(false)}>
+    <AutoCommandForm command={RegisterProject} exclude={['projectId']} />
+</CommandDialog>
+```
+
+A property whose type has no registered provider - a nested object, an array, an enum - is left out of the generated list. Add it as a hand-written `CommandForm` field alongside `AutoCommandForm`, or register a provider for it (see below).
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `command` | `Constructor<TCommand>` | — | **Required.** The command type to generate fields for. |
+| `exclude` | `(keyof TCommand)[]` | — | Property names to leave out of the generated field list. |
+
+`AutoCommandForm` also accepts every other `CommandForm` prop (`initialValues`, `populateFromQuery`, `onSuccess`, `validateOn`, and so on) except `children`, which it generates itself.
+
+## Registering a field type provider
+
+The built-in providers cover `string`, `number`, `boolean` and `Date`. Register your own for any other property type - a Cratis concept, an enum, a custom value object - with `registerFieldTypeProvider`:
+
+```tsx
+import { registerFieldTypeProvider } from '@cratis/components/CommandForm';
+import { DropdownField } from '@cratis/components/CommandForm';
+import { Status } from './Status';
+
+registerFieldTypeProvider({
+    canHandle: propertyDescriptor => propertyDescriptor.type === Status,
+    component: DropdownField
+});
+```
+
+Register once, at module load, before any `AutoCommandForm` renders. Providers are consulted most-recently-registered first, so registering a provider for a type the built-in defaults already cover - `string`, say - overrides that default.
+
+## Behavior
+
+- Field titles are generated from the property name (`dueDate` becomes "Due date"); there is no way to override an individual generated field's title other than excluding it and writing that one field by hand.
+- Every generated field participates in `CommandForm`'s validation, change tracking and initial-value population exactly as a hand-written field does - `AutoCommandForm` only decides *which* fields to render, not how they behave once rendered.

--- a/Documentation/CommandForm/index.md
+++ b/Documentation/CommandForm/index.md
@@ -18,7 +18,7 @@ CommandForm offers a complete set of form field components designed to work seam
 
 The CommandForm module exports specialized field components built on [PrimeReact](https://primereact.org/) primitives. Each field wraps a PrimeReact component using `asCommandFormField`, providing automatic value binding, validation state, and integration with Cratis Arc commands.
 
-See the field type pages in this section for documentation on each available field component.
+See the field type pages in this section for documentation on each available field component. To generate a form's fields from a command's own properties instead of writing them out by hand, see [AutoCommandForm](auto-command-form.md).
 
 ## Type-Safe Binding
 

--- a/Documentation/CommandForm/toc.yml
+++ b/Documentation/CommandForm/toc.yml
@@ -1,5 +1,7 @@
 - name: Overview
   href: index.md
+- name: AutoCommandForm
+  href: auto-command-form.md
 - name: CalendarField
   href: calendar-field.md
 - name: CheckboxField

--- a/Source/CommandForm/AutoCommandForm.stories.tsx
+++ b/Source/CommandForm/AutoCommandForm.stories.tsx
@@ -1,0 +1,57 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
+import { Command, CommandValidator } from '@cratis/arc/commands';
+import { PropertyDescriptor } from '@cratis/arc/reflection';
+import { StoryContainer, StorySection } from '@cratis/arc.react/stories';
+import '@cratis/arc/validation';
+import { AutoCommandForm } from './AutoCommandForm';
+
+const meta: Meta = {
+    title: 'CommandForm/Auto Command Form',
+    parameters: {
+        layout: 'centered',
+    },
+};
+
+export default meta;
+type Story = StoryObj;
+
+class RegisterProjectCommand extends Command {
+    readonly route: string = '/api/register-project';
+    readonly validation: CommandValidator<RegisterProjectCommand> = new (class extends CommandValidator<RegisterProjectCommand> { })();
+    readonly propertyDescriptors: PropertyDescriptor[] = [
+        new PropertyDescriptor('projectId', String),
+        new PropertyDescriptor('name', String),
+        new PropertyDescriptor('budget', Number),
+        new PropertyDescriptor('isBillable', Boolean),
+        new PropertyDescriptor('startDate', Date),
+    ];
+
+    projectId = '';
+    name = '';
+    budget = 0;
+    isBillable = false;
+    startDate = new Date();
+
+    get requestParameters(): string[] {
+        return [];
+    }
+
+    constructor() {
+        super(Object, false);
+    }
+}
+
+export const Default: Story = {
+    render: () => (
+        <StoryContainer>
+            <StorySection>
+                <h3>Fields generated from RegisterProjectCommand's own properties</h3>
+                <AutoCommandForm command={RegisterProjectCommand} exclude={['projectId']} />
+            </StorySection>
+        </StoryContainer>
+    ),
+};

--- a/Source/CommandForm/AutoCommandForm.tsx
+++ b/Source/CommandForm/AutoCommandForm.tsx
@@ -1,0 +1,71 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React, { useMemo } from 'react';
+import { Command } from '@cratis/arc/commands';
+import { CommandForm, CommandFormProps } from '@cratis/arc.react/commands';
+import { resolveFieldTypeProvider } from './fieldTypeProviderRegistry';
+import './defaultFieldTypeProviders';
+
+/**
+ * Props for {@link AutoCommandForm} - every {@link CommandFormProps} except `children`, which is
+ * generated from the command's own properties instead of being written out by hand.
+ */
+export interface AutoCommandFormProps<TCommand extends object, TResponse = object> extends Omit<CommandFormProps<TCommand, TResponse>, 'children'> {
+    /**
+     * Property names to leave out of the generated field list - for a property that should not
+     * be user-editable, or one a custom field placed elsewhere on the page already covers.
+     */
+    exclude?: (keyof TCommand)[];
+}
+
+function formatTitle(propertyName: string): string {
+    return propertyName
+        .replace(/([A-Z])/g, ' $1')
+        .replace(/^./, character => character.toUpperCase())
+        .trim();
+}
+
+/**
+ * A `CommandForm` that generates its field list from the command's own properties, choosing each
+ * field's component by the property's type through the {@link FieldTypeProvider} registry -
+ * `registerFieldTypeProvider` for a type the built-in defaults (`string`, `number`, `boolean`,
+ * `Date`) don't cover, or to override one of them.
+ *
+ * A property whose type no registered provider handles is left out of the generated list -
+ * `exclude` it explicitly for clarity, or add a `CommandForm` child by hand alongside this
+ * component for that one property.
+ *
+ * @example
+ * ```tsx
+ * <AutoCommandForm command={RegisterInvoice} exclude={['invoiceId']} />
+ * ```
+ */
+export function AutoCommandForm<TCommand extends object = object, TResponse = object>(
+    props: AutoCommandFormProps<TCommand, TResponse>
+): React.ReactElement {
+    const { exclude, ...commandFormProps } = props;
+    const propertyDescriptors = useMemo(() => (new props.command() as unknown as Command).propertyDescriptors, [props.command]);
+    const excluded = useMemo(() => new Set<string>((exclude ?? []) as string[]), [exclude]);
+
+    const fields = propertyDescriptors
+        .filter(descriptor => !excluded.has(descriptor.name))
+        .map(descriptor => {
+            const provider = resolveFieldTypeProvider(descriptor);
+            if (!provider) {
+                return null;
+            }
+
+            const Field = provider.component;
+            return (
+                <Field
+                    key={descriptor.name}
+                    value={(instance: TCommand) => (instance as unknown as Record<string, unknown>)[descriptor.name]}
+                    title={formatTitle(descriptor.name)}
+                />
+            );
+        })
+        .filter((field): field is React.ReactElement => field !== null);
+
+    return <CommandForm {...commandFormProps}>{fields}</CommandForm>;
+}

--- a/Source/CommandForm/FieldTypeProvider.ts
+++ b/Source/CommandForm/FieldTypeProvider.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { PropertyDescriptor } from '@cratis/arc/reflection';
+import { ComponentType } from 'react';
+
+/**
+ * Maps a command property's type to the field component that renders it by default in
+ * {@link AutoCommandForm}.
+ */
+export interface FieldTypeProvider {
+    /**
+     * Determines whether this provider renders the given property.
+     * @param propertyDescriptor The property to consider.
+     * @returns True if this provider handles the property's type.
+     */
+    canHandle(propertyDescriptor: PropertyDescriptor): boolean;
+
+    /**
+     * The field component to render for a property this provider handles - one of the field
+     * components built with `asCommandFormField` (e.g. `InputTextField`, `NumberField`).
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    component: ComponentType<any>;
+}

--- a/Source/CommandForm/defaultFieldTypeProviders.ts
+++ b/Source/CommandForm/defaultFieldTypeProviders.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { registerFieldTypeProvider } from './fieldTypeProviderRegistry';
+import { InputTextField } from './fields/InputTextField';
+import { NumberField } from './fields/NumberField';
+import { CheckboxField } from './fields/CheckboxField';
+import { CalendarField } from './fields/CalendarField';
+
+/**
+ * Registers the built-in {@link FieldTypeProvider}s {@link AutoCommandForm} falls back to for the
+ * JavaScript primitive types a command property can have. Registered once, on module load.
+ */
+export function registerDefaultFieldTypeProviders(): void {
+    registerFieldTypeProvider({ canHandle: descriptor => descriptor.type === String, component: InputTextField });
+    registerFieldTypeProvider({ canHandle: descriptor => descriptor.type === Number, component: NumberField });
+    registerFieldTypeProvider({ canHandle: descriptor => descriptor.type === Boolean, component: CheckboxField });
+    registerFieldTypeProvider({ canHandle: descriptor => descriptor.type === Date, component: CalendarField });
+}
+
+registerDefaultFieldTypeProviders();

--- a/Source/CommandForm/fieldTypeProviderRegistry.ts
+++ b/Source/CommandForm/fieldTypeProviderRegistry.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { PropertyDescriptor } from '@cratis/arc/reflection';
+import { FieldTypeProvider } from './FieldTypeProvider';
+
+const providers: FieldTypeProvider[] = [];
+
+/**
+ * Registers a {@link FieldTypeProvider} that {@link AutoCommandForm} consults when choosing which
+ * field component to render for a command property.
+ *
+ * Providers are consulted most-recently-registered first, so a provider registered by consuming
+ * application code overrides one of the built-in defaults for the same property type.
+ * @param provider The provider to register.
+ */
+export function registerFieldTypeProvider(provider: FieldTypeProvider): void {
+    providers.unshift(provider);
+}
+
+/**
+ * Finds the first registered {@link FieldTypeProvider} that handles the given property.
+ * @param propertyDescriptor The property to resolve a provider for.
+ * @returns The matching provider, or undefined if none handles this property's type.
+ */
+export function resolveFieldTypeProvider(propertyDescriptor: PropertyDescriptor): FieldTypeProvider | undefined {
+    return providers.find(provider => provider.canHandle(propertyDescriptor));
+}
+
+/**
+ * Clears every registered provider, including the built-in defaults. Exposed for specs; a
+ * consuming application should not normally call this.
+ */
+export function clearFieldTypeProviders(): void {
+    providers.length = 0;
+}

--- a/Source/CommandForm/for_fieldTypeProviderRegistry/when_a_later_provider_is_registered_for_an_already_handled_type.ts
+++ b/Source/CommandForm/for_fieldTypeProviderRegistry/when_a_later_provider_is_registered_for_an_already_handled_type.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { PropertyDescriptor } from '@cratis/arc/reflection';
+import { clearFieldTypeProviders, registerFieldTypeProvider, resolveFieldTypeProvider } from '../fieldTypeProviderRegistry';
+import { InputTextField } from '../fields/InputTextField';
+import { TextAreaField } from '../fields/TextAreaField';
+
+describe('when a later provider is registered for an already handled type', () => {
+    let result: ReturnType<typeof resolveFieldTypeProvider>;
+
+    beforeEach(() => {
+        clearFieldTypeProviders();
+        registerFieldTypeProvider({ canHandle: descriptor => descriptor.type === String, component: InputTextField });
+        registerFieldTypeProvider({ canHandle: descriptor => descriptor.type === String, component: TextAreaField });
+
+        result = resolveFieldTypeProvider(new PropertyDescriptor('name', String, false));
+    });
+
+    it('should prefer the most recently registered provider', () => {
+        result!.component.should.equal(TextAreaField);
+    });
+});

--- a/Source/CommandForm/for_fieldTypeProviderRegistry/when_resolving_a_provider_for_a_known_type.ts
+++ b/Source/CommandForm/for_fieldTypeProviderRegistry/when_resolving_a_provider_for_a_known_type.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { PropertyDescriptor } from '@cratis/arc/reflection';
+import { clearFieldTypeProviders, registerFieldTypeProvider, resolveFieldTypeProvider } from '../fieldTypeProviderRegistry';
+import { InputTextField } from '../fields/InputTextField';
+
+describe('when resolving a provider for a known type', () => {
+    let result: ReturnType<typeof resolveFieldTypeProvider>;
+
+    beforeEach(() => {
+        clearFieldTypeProviders();
+        registerFieldTypeProvider({ canHandle: descriptor => descriptor.type === String, component: InputTextField });
+
+        result = resolveFieldTypeProvider(new PropertyDescriptor('name', String, false));
+    });
+
+    it('should return the registered provider', () => {
+        result!.component.should.equal(InputTextField);
+    });
+});

--- a/Source/CommandForm/for_fieldTypeProviderRegistry/when_resolving_a_provider_for_an_unregistered_type.ts
+++ b/Source/CommandForm/for_fieldTypeProviderRegistry/when_resolving_a_provider_for_an_unregistered_type.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { PropertyDescriptor } from '@cratis/arc/reflection';
+import { clearFieldTypeProviders, resolveFieldTypeProvider } from '../fieldTypeProviderRegistry';
+
+describe('when resolving a provider for an unregistered type', () => {
+    let result: ReturnType<typeof resolveFieldTypeProvider>;
+
+    beforeEach(() => {
+        clearFieldTypeProviders();
+        result = resolveFieldTypeProvider(new PropertyDescriptor('id', Object, false));
+    });
+
+    it('should return undefined', () => {
+        (result === undefined).should.be.true;
+    });
+});

--- a/Source/CommandForm/for_fieldTypeProviderRegistry/when_resolving_the_default_providers.ts
+++ b/Source/CommandForm/for_fieldTypeProviderRegistry/when_resolving_the_default_providers.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { PropertyDescriptor } from '@cratis/arc/reflection';
+import { clearFieldTypeProviders, resolveFieldTypeProvider } from '../fieldTypeProviderRegistry';
+import { registerDefaultFieldTypeProviders } from '../defaultFieldTypeProviders';
+import { InputTextField } from '../fields/InputTextField';
+import { NumberField } from '../fields/NumberField';
+import { CheckboxField } from '../fields/CheckboxField';
+import { CalendarField } from '../fields/CalendarField';
+
+describe('when resolving the default providers', () => {
+    beforeEach(() => {
+        clearFieldTypeProviders();
+        registerDefaultFieldTypeProviders();
+    });
+
+    it('should resolve a string property to InputTextField', () => {
+        resolveFieldTypeProvider(new PropertyDescriptor('name', String, false))!.component.should.equal(InputTextField);
+    });
+
+    it('should resolve a number property to NumberField', () => {
+        resolveFieldTypeProvider(new PropertyDescriptor('age', Number, false))!.component.should.equal(NumberField);
+    });
+
+    it('should resolve a boolean property to CheckboxField', () => {
+        resolveFieldTypeProvider(new PropertyDescriptor('active', Boolean, false))!.component.should.equal(CheckboxField);
+    });
+
+    it('should resolve a Date property to CalendarField', () => {
+        resolveFieldTypeProvider(new PropertyDescriptor('startedAt', Date, false))!.component.should.equal(CalendarField);
+    });
+});

--- a/Source/CommandForm/index.ts
+++ b/Source/CommandForm/index.ts
@@ -2,3 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 export * from './fields';
+export * from './FieldTypeProvider';
+export * from './fieldTypeProviderRegistry';
+export * from './AutoCommandForm';


### PR DESCRIPTION
## Added

- `AutoCommandForm` - generates a `CommandForm`'s field list from the command's own `propertyDescriptors` instead of writing one field per property by hand, choosing each field's component by property type through a `FieldTypeProvider` registry. Built-in providers cover `string`, `number`, `boolean` and `Date`.
- `registerFieldTypeProvider` - registers a provider for any other property type (a Cratis concept, an enum, a custom value object). Most-recently-registered wins, so a provider registered by consuming application code overrides one of the built-in defaults.
- `exclude` prop on `AutoCommandForm` to leave specific properties out of the generated field list.
- New [AutoCommandForm](https://github.com/Cratis/Components/blob/main/Documentation/CommandForm/auto-command-form.md) documentation page and a Storybook story.

(#104)

## Notes for reviewers

The issue frames this as "built on top of a provider model in Arc," but the provider registry lives entirely in this repo instead. Arc.React has no knowledge of Components' concrete PrimeReact-based field implementations (`InputTextField`, `NumberField`, ...) and doesn't need any - `Command.propertyDescriptors` already exposes everything `AutoCommandForm` needs, with no Arc changes required. Keeping the type-to-component mapping where the component implementations actually live avoids Arc.React taking on a dependency direction back toward Components.

`AutoCommandForm` computes its field list itself and passes the resulting elements as `CommandForm`'s own children (rather than, say, a child component `CommandForm` discovers on its own) - `CommandForm`'s field detection walks `props.children` as written, without rendering nested components to see what they produce, so the generated fields have to already be real children by the time `CommandForm` processes them. This was confirmed by reading `CommandForm.tsx`'s `getCommandFormFields` before committing to the design, rather than assumed.