### PR TITLE
Use CSS comments for the license header in Properties.css

### DIFF
--- a/Source/TimeMachine/Properties.css
+++ b/Source/TimeMachine/Properties.css
@@ -1,5 +1,5 @@
-// Copyright (c) Cratis. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+/* Copyright (c) Cratis. All rights reserved. */
+/* Licensed under the MIT license. See LICENSE file in the project root for full license information. */
 
 .tm-properties-table {
     width: 100%;


### PR DESCRIPTION
### Fixed

- `TimeMachine/Properties.css` used `//` for its license header, which is not a comment in CSS. It shipped that way in both `dist/esm` and `dist/cjs`, so a consumer building with Vite's lightningcss minifier had the whole bundle rejected. It is now the `/* */` form every other stylesheet in the repo already uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)