### PR TITLE
Expose the array-driven data table

### DIFF
--- a/Source/DataTables/index.ts
+++ b/Source/DataTables/index.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+export * from './DataTableCore';
 export * from './DataTableForQuery';
 export * from './DataTableForObservableQuery';
 export * from './Column';


### PR DESCRIPTION
### Added

- `DataTableCore` is now exported from `@cratis/components/DataTables`, so an application can render rows it already holds — fetched by hand, computed, or assembled from several sources — with `Column` children, selection, filtering and scrolling, without driving a query through `DataTableForQuery` or `DataTableForObservableQuery`.

This matters for the PrimeReact 11 migration. Version 10's `DataTable` took a `value` array with `Column` children; version 11 replaces it with a headless compound surface (`Root`, `Table`, `THead`, `Row`, `Cell`) and removes `Column` entirely, so every array-driven table would otherwise have to be reassembled by hand at each call site.

The component is unchanged — it is what both query wrappers already render internally, and was simply never re-exported.