### PR TITLE
Add flat Message and ProgressSpinner to Display

### DIFF
--- a/Source/Display/Display.stories.tsx
+++ b/Source/Display/Display.stories.tsx
@@ -9,6 +9,8 @@ import { Chip } from './Chip';
 import { Skeleton } from './Skeleton';
 import { Avatar } from './Avatar';
 import { ProgressBar } from './ProgressBar';
+import { Message } from './Message';
+import { ProgressSpinner } from './ProgressSpinner';
 
 const meta = {
     title: 'Display/Overview',
@@ -54,6 +56,16 @@ export const Overview: Story = {
                 <div style={{ flex: 1, minWidth: '200px' }}>
                     <ProgressBar value={65} />
                 </div>
+            </Row>
+            <Row label="Message">
+                <div style={{ flex: 1, minWidth: '200px', display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+                    <Message severity="info" text="An informational notice." />
+                    <Message severity="warn" text="Something needs attention." />
+                    <Message severity="error">Something went wrong.</Message>
+                </div>
+            </Row>
+            <Row label="ProgressSpinner">
+                <ProgressSpinner style={{ width: '2rem', height: '2rem' }} />
             </Row>
             <Row label="ProgressBar (indeterminate)">
                 <div style={{ flex: 1, minWidth: '200px' }}>

--- a/Source/Display/Message.tsx
+++ b/Source/Display/Message.tsx
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { Message as PrimeMessage } from 'primereact/message';
+
+/** Severity tone of a {@link Message}. */
+export type MessageSeverity = 'info' | 'success' | 'warn' | 'error' | 'secondary' | 'contrast';
+
+/** Props for {@link Message}. */
+export interface MessageProps {
+    /** Severity tone (drives the color). */
+    severity?: MessageSeverity;
+    /** The message text. */
+    text?: React.ReactNode;
+    /** Message content (alternative to {@link text}). */
+    children?: React.ReactNode;
+    /** Extra class name applied to the message root. */
+    className?: string;
+}
+
+/**
+ * A declarative inline message built on PrimeReact 11's compositional `Message` parts.
+ *
+ * PrimeReact 10's `<Message severity text />` became `Message.Root` + `Message.Content` +
+ * `Message.Text` in 11; this preserves the flat call shape so an inline notice stays a
+ * single element at the call site.
+ */
+export const Message = ({ severity = 'info', text, children, className }: MessageProps) => (
+    <PrimeMessage.Root severity={severity} className={className}>
+        <PrimeMessage.Content>
+            <PrimeMessage.Text>{children ?? text}</PrimeMessage.Text>
+        </PrimeMessage.Content>
+    </PrimeMessage.Root>
+);

--- a/Source/Display/ProgressSpinner.tsx
+++ b/Source/Display/ProgressSpinner.tsx
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { ProgressSpinner as PrimeProgressSpinner } from 'primereact/progressspinner';
+
+/** Props for {@link ProgressSpinner}. */
+export interface ProgressSpinnerProps {
+    /** Applied to the spinner root — use it to size the spinner. */
+    style?: React.CSSProperties;
+    /** Extra class name applied to the spinner root. */
+    className?: string;
+    /** Announced to assistive technology while the spinner is visible. */
+    'aria-label'?: string;
+}
+
+/**
+ * An indeterminate spinner built on PrimeReact 11's compositional `ProgressSpinner` parts.
+ *
+ * PrimeReact 10's single `<ProgressSpinner />` became `ProgressSpinner.Root` + `Track` +
+ * `Range` in 11; this preserves the flat call shape for the common loading indicator.
+ */
+export const ProgressSpinner = ({ style, className, 'aria-label': ariaLabel = 'Loading' }: ProgressSpinnerProps) => (
+    <PrimeProgressSpinner.Root style={style} className={className} aria-label={ariaLabel}>
+        <PrimeProgressSpinner.Track />
+        <PrimeProgressSpinner.Range />
+    </PrimeProgressSpinner.Root>
+);

--- a/Source/Display/index.ts
+++ b/Source/Display/index.ts
@@ -7,3 +7,5 @@ export * from './Chip';
 export * from './Skeleton';
 export * from './Avatar';
 export * from './ProgressBar';
+export * from './Message';
+export * from './ProgressSpinner';


### PR DESCRIPTION
### Added

- `Message` — a declarative inline message from `@cratis/components/Display`, preserving PrimeReact 10's flat `<Message severity text />` call shape over PrimeReact 11's compositional `Message.Root`/`Content`/`Text` parts.
- `ProgressSpinner` — an indeterminate spinner from `@cratis/components/Display`, preserving the flat `<ProgressSpinner />` call shape over PrimeReact 11's `Root`/`Track`/`Range` parts.

Both originated in Chronicle's Workbench migration to PrimeReact 11; with Studio as a second consumer they move into the shared library.