### PR TITLE
Add a Button carrying label, icon, loading and tooltip

### DIFF
--- a/Source/Common/Button.stories.tsx
+++ b/Source/Common/Button.stories.tsx
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import { Button } from './Button';
+
+const meta = {
+    title: 'Common/Button',
+    component: Button,
+    parameters: { layout: 'padded' },
+    tags: ['autodocs'],
+    args: { onClick: fn() },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Label: Story = { args: { label: 'Save' } };
+export const LabelAndIcon: Story = { args: { label: 'Save', icon: 'pi pi-check' } };
+export const IconOnly: Story = { args: { icon: 'pi pi-trash', 'aria-label': 'Delete', severity: 'danger' } };
+export const Loading: Story = { args: { label: 'Saving', loading: true } };
+export const Text: Story = { args: { label: 'Cancel', text: true } };
+export const Outlined: Story = { args: { label: 'Details', outlined: true, severity: 'secondary' } };
+export const WithTooltip: Story = { args: { icon: 'pi pi-info-circle', 'aria-label': 'Info', tooltip: 'More information' } };

--- a/Source/Common/Button.tsx
+++ b/Source/Common/Button.tsx
@@ -1,0 +1,115 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { type CSSProperties, type MouseEventHandler, type ReactNode } from 'react';
+import { Button as PrimeButton } from 'primereact/button';
+import type { ButtonProps as ButtonRootProps } from '@primereact/types/primitive/button';
+import { Tooltip, type TooltipPosition } from './Tooltip';
+
+/** Severity tone of a {@link Button}. */
+export type ButtonSeverity = 'secondary' | 'info' | 'success' | 'warn' | 'help' | 'danger' | 'contrast';
+
+/**
+ * Props for {@link Button}.
+ */
+export interface ButtonProps {
+    /** The button's text. */
+    label?: ReactNode;
+    /**
+     * The button's icon — either a PrimeIcons class name (`'pi pi-check'`) or an
+     * element. Rendered before the label.
+     */
+    icon?: ReactNode;
+    /** Replaces the icon with a spinner and disables the button. */
+    loading?: boolean;
+    /** Text shown on hover. */
+    tooltip?: string;
+    /** Placement of the tooltip. */
+    tooltipOptions?: { position?: TooltipPosition; className?: string };
+    /** PrimeReact pass-through for the underlying button. */
+    pt?: ButtonRootProps['pt'];
+    /** Renders the button borderless. */
+    text?: boolean;
+    /** Renders the button with an outline instead of a fill. */
+    outlined?: boolean;
+    /** Renders the button fully rounded. */
+    rounded?: boolean;
+    /** Controls the button's coloring. */
+    severity?: ButtonSeverity;
+    /** Sizes the button. */
+    size?: 'small' | 'normal' | 'large';
+    /** Whether the button is disabled. */
+    disabled?: boolean;
+    /** Native button type. */
+    type?: 'button' | 'submit' | 'reset';
+    /** Called when the button is activated. */
+    onClick?: MouseEventHandler<HTMLButtonElement>;
+    /** Applied to the button element. */
+    className?: string;
+    /** Applied to the button element. */
+    style?: CSSProperties;
+    /** Accessible name — required when the button renders an icon and no label. */
+    'aria-label'?: string;
+    /** Rendered inside the button, after the icon and label. */
+    children?: ReactNode;
+}
+
+const renderIcon = (icon: ReactNode) =>
+    typeof icon === 'string' ? <i className={icon} aria-hidden='true' /> : icon;
+
+/**
+ * A button carrying the `label` / `icon` / `loading` / `tooltip` authoring model.
+ *
+ * PrimeReact 11's `Button` takes its content as **children** and dropped `label`,
+ * `icon`, `loading`, `tooltip` and `text` entirely. Because its props type is
+ * generic over `React.ElementType`, those props are still *accepted by the
+ * compiler* and silently ignored at runtime — a `<Button label="Save" />`
+ * typechecks and renders an empty button. This wrapper closes that trap once, for
+ * every application, rather than leaving each call site to be caught by eye.
+ */
+export const Button = ({
+    label,
+    icon,
+    loading,
+    tooltip,
+    tooltipOptions,
+    pt,
+    text,
+    outlined,
+    rounded,
+    severity,
+    size,
+    disabled,
+    type = 'button',
+    onClick,
+    className,
+    style,
+    'aria-label': ariaLabel,
+    children
+}: ButtonProps) => {
+    const variant = text ? 'text' : outlined ? 'outlined' : undefined;
+
+    const button = (
+        <PrimeButton
+            type={type}
+            variant={variant}
+            rounded={rounded}
+            severity={severity}
+            size={size}
+            iconOnly={!!icon && label === undefined && !children}
+            disabled={disabled || loading}
+            onClick={onClick}
+            className={className}
+            style={style}
+            aria-label={ariaLabel}
+            pt={pt}>
+            {loading ? <i className='pi pi-spinner pi-spin' aria-hidden='true' /> : renderIcon(icon)}
+            {label}
+            {children}
+        </PrimeButton>
+    );
+
+    return tooltip
+        ? <Tooltip content={tooltip} position={tooltipOptions?.position} className={tooltipOptions?.className}>{button}</Tooltip>
+        : button;
+};

--- a/Source/Common/index.ts
+++ b/Source/Common/index.ts
@@ -10,3 +10,4 @@ export * from './normalizeIconClass';
 export * from './Page';
 export * from './FormElement';
 export * from './Tooltip';
+export * from './Button';


### PR DESCRIPTION
### Added

- `Button` from `@cratis/components/Common` — preserves PrimeReact 10's `label` / `icon` / `loading` / `tooltip` / `text` / `outlined` authoring model over PrimeReact 11's children-only `Button`. Accepts a PrimeIcons class name or an element for `icon`, renders a spinner while `loading`, and sets `iconOnly` automatically when there is an icon and no label.

This closes a silent trap in the PrimeReact 11 migration: v11's `Button` props are generic over `React.ElementType`, so `<Button label="Save" icon="pi pi-check" />` still typechecks — and renders an empty button. Nothing fails at build time; only a person looking at the screen catches it.