### PR TITLE
Add the link variant to Button

### DIFF
--- a/Source/Common/Button.stories.tsx
+++ b/Source/Common/Button.stories.tsx
@@ -21,5 +21,6 @@ export const LabelAndIcon: Story = { args: { label: 'Save', icon: 'pi pi-check' 
 export const IconOnly: Story = { args: { icon: 'pi pi-trash', 'aria-label': 'Delete', severity: 'danger' } };
 export const Loading: Story = { args: { label: 'Saving', loading: true } };
 export const Text: Story = { args: { label: 'Cancel', text: true } };
+export const Link: Story = { args: { label: 'Learn more', link: true } };
 export const Outlined: Story = { args: { label: 'Details', outlined: true, severity: 'secondary' } };
 export const WithTooltip: Story = { args: { icon: 'pi pi-info-circle', 'aria-label': 'Info', tooltip: 'More information' } };

--- a/Source/Common/Button.tsx
+++ b/Source/Common/Button.tsx
@@ -30,6 +30,8 @@ export interface ButtonProps {
     pt?: ButtonRootProps['pt'];
     /** Renders the button borderless. */
     text?: boolean;
+    /** Renders the button as an inline link. */
+    link?: boolean;
     /** Renders the button with an outline instead of a fill. */
     outlined?: boolean;
     /** Renders the button fully rounded. */
@@ -75,6 +77,7 @@ export const Button = ({
     tooltipOptions,
     pt,
     text,
+    link,
     outlined,
     rounded,
     severity,
@@ -87,7 +90,7 @@ export const Button = ({
     'aria-label': ariaLabel,
     children
 }: ButtonProps) => {
-    const variant = text ? 'text' : outlined ? 'outlined' : undefined;
+    const variant = link ? 'link' : text ? 'text' : outlined ? 'outlined' : undefined;
 
     const button = (
         <PrimeButton


### PR DESCRIPTION
### Fixed

- `Button` from `@cratis/components/Common` now accepts `link`, mapping to PrimeReact 11's `variant: 'link'`, alongside the existing `text` and `outlined` flags. A PrimeReact 10 `<Button link />` previously rendered as a filled button.