### PR TITLE
Let query tables name the row type of a generated proxy

### DIFF
--- a/Source/DataTables/DataTableForObservableQuery.tsx
+++ b/Source/DataTables/DataTableForObservableQuery.tsx
@@ -18,7 +18,7 @@ import type { DataTableSelectionChangeEvent } from './DataTableSelectionChangeEv
  * @typeParam TDataType - The row type returned by the query.
  * @typeParam TArguments - The query's argument object type.
  */
-export interface DataTableForObservableQueryProps<TQuery extends IObservableQueryFor<TDataType, TArguments>, TDataType extends object, TArguments extends object> {
+export interface DataTableForObservableQueryProps<TQuery extends IObservableQueryFor<TDataType, TArguments> | IObservableQueryFor<TDataType[], TArguments>, TDataType extends object, TArguments extends object> {
     /**
      * Children to render — `<Column>` elements describing the visible columns.
      */
@@ -126,7 +126,7 @@ const paging = new Paging(0, 20);
  * @typeParam TArguments - The query's argument object type.
  * @param props - {@link DataTableForObservableQueryProps}.
  */
-export const DataTableForObservableQuery = <TQuery extends IObservableQueryFor<TDataType, TArguments>, TDataType extends object, TArguments extends object>(props: DataTableForObservableQueryProps<TQuery, TDataType, TArguments>) => {
+export const DataTableForObservableQuery = <TQuery extends IObservableQueryFor<TDataType, TArguments> | IObservableQueryFor<TDataType[], TArguments>, TDataType extends object, TArguments extends object>(props: DataTableForObservableQueryProps<TQuery, TDataType, TArguments>) => {
     // Type arguments are supplied explicitly, and the constructor is erased on the way in
     // (Cratis/Components#135). Two separate defects in `@cratis/arc.react` make the plain call
     // fail to type-check:

--- a/Source/DataTables/DataTableForQuery.tsx
+++ b/Source/DataTables/DataTableForQuery.tsx
@@ -18,7 +18,7 @@ import type { DataTableSelectionChangeEvent } from './DataTableSelectionChangeEv
  * @typeParam TDataType - The row type returned by the query.
  * @typeParam TArguments - The query's argument object type, or `object` if it takes none.
  */
-export interface DataTableForQueryProps<TQuery extends IQueryFor<TDataType, TArguments>, TDataType extends object, TArguments extends object> {
+export interface DataTableForQueryProps<TQuery extends IQueryFor<TDataType, TArguments> | IQueryFor<TDataType[], TArguments>, TDataType extends object, TArguments extends object> {
     /**
      * Children to render — `<Column>` elements describing the visible columns.
      */
@@ -139,7 +139,7 @@ const paging = new Paging(0, 20);
  * @typeParam TArguments - The query's argument object type.
  * @param props - {@link DataTableForQueryProps}.
  */
-export const DataTableForQuery = <TQuery extends IQueryFor<TDataType, TArguments>, TDataType extends object, TArguments extends object>(props: DataTableForQueryProps<TQuery, TDataType, TArguments>) => {
+export const DataTableForQuery = <TQuery extends IQueryFor<TDataType, TArguments> | IQueryFor<TDataType[], TArguments>, TDataType extends object, TArguments extends object>(props: DataTableForQueryProps<TQuery, TDataType, TArguments>) => {
     const [result, , , setPage] = useQueryWithPaging(props.query, paging, props.queryArguments);
     const totalItems = result.paging.totalItems;
     const pageCount = result.paging.totalPages;

--- a/Source/DataTables/for_DataTableForQuery/given/a_data_table.ts
+++ b/Source/DataTables/for_DataTableForQuery/given/a_data_table.ts
@@ -7,7 +7,7 @@ import { createRoot, type Root } from 'react-dom/client';
 import { CratisComponentsProvider } from '../../../Common/CratisComponentsProvider';
 import { Column } from '../../Column';
 import { DataTableForQuery } from '../../DataTableForQuery';
-import { ProductsQuery, resetQueryResult } from './a_query_result';
+import { GeneratedProductsQuery, type Product, ProductsQuery, resetQueryResult } from './a_query_result';
 
 /**
  * A data table mounted into a real document, together with what is needed to
@@ -28,6 +28,25 @@ export const aDataTable = () => React.createElement(
         query: ProductsQuery,
         emptyMessage: 'No products found',
         dataKey: 'id'
+    },
+    React.createElement(Column, { key: 'id', field: 'id', header: 'Id' }),
+    React.createElement(Column, { key: 'name', field: 'name', header: 'Name' }));
+
+/**
+ * Builds a `DataTableForQuery` over a proxy shaped like Arc's generated ones (an array-typed
+ * data type) while naming the row type explicitly - the form a selectable table needs so its
+ * `selection` and `onSelectionChange` are typed to the row rather than to `object`. That this
+ * compiles is the point: the generic constraint used to reject it.
+ * @param onSelectionChange - Receives the typed selection.
+ * @returns The element.
+ */
+export const aDataTableOverAGeneratedProxy = (onSelectionChange: (product: Product | null) => void) => React.createElement(
+    DataTableForQuery<GeneratedProductsQuery, Product, object>,
+    {
+        query: GeneratedProductsQuery,
+        emptyMessage: 'No products found',
+        dataKey: 'id',
+        onSelectionChange: (event) => onSelectionChange(event.value)
     },
     React.createElement(Column, { key: 'id', field: 'id', header: 'Id' }),
     React.createElement(Column, { key: 'name', field: 'name', header: 'Name' }));

--- a/Source/DataTables/for_DataTableForQuery/given/a_query_result.ts
+++ b/Source/DataTables/for_DataTableForQuery/given/a_query_result.ts
@@ -108,3 +108,29 @@ export class ProductsQuery extends QueryFor<Product, object> {
         return Promise.resolve({ data: rowsForCurrentPage() } as unknown as QueryResult<Product>);
     }
 }
+
+/**
+ * A snapshot query proxy shaped exactly like the ones Arc generates: the data type is the
+ * row *array*, not the row. {@link ProductsQuery} above names the row so the table's generics
+ * infer without help; this one exists so a spec can prove that a real, array-typed proxy is
+ * accepted while the row type is still named explicitly - the shape every consumer with a
+ * selectable table has to write.
+ */
+export class GeneratedProductsQuery extends QueryFor<Product[], object> {
+    readonly route = '/api/products';
+    readonly routeTemplate = '/api/products';
+    readonly defaultValue: Product[] = [];
+    readonly parameterDescriptors = [];
+
+    get requiredRequestParameters(): string[] {
+        return [];
+    }
+
+    constructor() {
+        super(Object, true);
+    }
+
+    override perform(): Promise<QueryResult<Product[]>> {
+        return Promise.resolve({ data: rowsForCurrentPage() } as unknown as QueryResult<Product[]>);
+    }
+}

--- a/Source/DataTables/for_DataTableForQuery/when_rendering_a_result/and_the_query_is_a_generated_proxy.ts
+++ b/Source/DataTables/for_DataTableForQuery/when_rendering_a_result/and_the_query_is_a_generated_proxy.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// @vitest-environment jsdom
+
+import { vi } from 'vitest';
+import { aDataTableOverAGeneratedProxy, type DataTableInTheDom, hasPaginator, render, unmount } from '../given/a_data_table';
+import { queryResult, type Product } from '../given/a_query_result';
+
+vi.mock('@cratis/arc.react/queries', async () => {
+    const { arcQueryHooks } = await import('../given/a_query_result');
+    return arcQueryHooks();
+});
+
+/**
+ * Arc generates proxies as `QueryFor<Row[], Arguments>` - the data type is the array. The
+ * table's row generic is `TDataType`, so a consumer who wants typed selection has to write
+ * `<DataTableForQuery<TheProxy, Row, Arguments>>`. The constraint used to reject exactly that
+ * combination (TS2344), which forced every selectable table down to `object`. This spec is the
+ * compile-time proof that a real proxy and a named row type coexist, and the runtime proof that
+ * such a table still renders.
+ */
+describe('when rendering a result and the query is a generated proxy', () => {
+    let table: DataTableInTheDom;
+    let selected: Product | null | undefined;
+
+    beforeEach(async () => {
+        queryResult.totalItems = 24;
+        queryResult.totalPages = 2;
+        table = await render(aDataTableOverAGeneratedProxy((product) => { selected = product; }));
+    });
+
+    afterEach(async () => {
+        await unmount(table);
+    });
+
+    it('should render the paginator', () => {
+        hasPaginator(table).should.be.true;
+    });
+
+    it('should not have selected anything before the user does', () => {
+        (selected === undefined).should.be.true;
+    });
+});


### PR DESCRIPTION
### Fixed

- `DataTableForQuery` and `DataTableForObservableQuery` now accept a query proxy typed the way Arc generates them — `QueryFor<Row[], Arguments>` — while the row type is named explicitly (`<DataTableForQuery<TheProxy, Row, Arguments>>`). Previously that combination failed with TS2344, so a selectable table could only type its `selection` and `onSelectionChange` as `object`.