### PR TITLE
Stamp data-severity on Button so the theme can color it

### DIFF
--- a/Source/Common/Button.tsx
+++ b/Source/Common/Button.tsx
@@ -72,6 +72,9 @@ const renderIcon = (icon: ReactNode) =>
  * compiler* and silently ignored at runtime — a `<Button label="Save" />`
  * typechecks and renders an empty button. This wrapper closes that trap once, for
  * every application, rather than leaving each call site to be caught by eye.
+ *
+ * `severity` is also stamped as `data-severity` on the element: the Cratis theme colors
+ * by that attribute (as {@link Tag} does), and PrimeReact 11's button does not emit it.
  */
 export const Button = ({
     label,
@@ -113,6 +116,7 @@ export const Button = ({
             className={className}
             style={style}
             aria-label={ariaLabel}
+            data-severity={severity}
             pt={pt}>
             {loading ? <i className='pi pi-spinner pi-spin' aria-hidden='true' /> : renderIcon(icon)}
             {label}


### PR DESCRIPTION
### Fixed

- `Button` from `@cratis/components/Common` now stamps its `severity` as a `data-severity` attribute, matching `Tag`, so the Cratis theme's severity colors apply. Previously a `severity='danger'` button rendered in the primary color.