### PR TITLE
Add PrimeReact's styled mode and the PrimeReact 10 palette

### DIFF
--- a/Documentation/Common/cratis-components-provider.md
+++ b/Documentation/Common/cratis-components-provider.md
@@ -4,7 +4,7 @@ Single setup point for Cratis Components. Wraps PrimeReact's `PrimeReactProvider
 
 ## Purpose
 
-- Hosts the PrimeReact `pt` / `unstyled` / `ptOptions` / `inputVariant` / `ripple` / `theme` / `zIndex` / `locale` configuration for every Cratis wrapper below it in the tree.
+- Hosts the PrimeReact `pt` / `unstyled` / `ptOptions` / `inputVariant` / `ripple` / `theme` / `defaults` / `zIndex` / `locale` configuration for every Cratis wrapper below it in the tree.
 - Deep-merges Cratis-wide defaults with the consumer's value, so future Cratis defaults can land without breaking consumer overrides.
 - Re-exported from the package root so the recommended setup is one import:
 
@@ -45,6 +45,23 @@ export const App = () => (
 
 The `value` is deep-merged with the Cratis defaults (currently empty) so consumer settings always win. Pass a stable reference (a module-level constant or a `useMemo` result) to avoid unnecessary re-renders.
 
+## PrimeReact's styled mode
+
+PrimeReact 11's primitives are unstyled: `theme: { preset }` on its own emits the `--p-*` design tokens but the elements carry no `p-*` class names, so a preset alone paints nothing. `styledMode()` from `@cratis/components/styled` returns the `theme` *and* the `defaults` (`primeReactStyles`, PrimeReact's own component styles keyed by primitive name) the provider needs to apply PrimeReact's look to every primitive rendered under it — this library's and your own. Spread it into `value` next to your license key:
+
+```tsx
+import { CratisComponentsProvider } from '@cratis/components';
+import { styledMode } from '@cratis/components/styled';
+
+export const App = () => (
+    <CratisComponentsProvider value={{ license: 'YOUR-PRIMEUI-KEY', ...styledMode() }}>
+        <YourApp />
+    </CratisComponentsProvider>
+);
+```
+
+It needs `@primereact/styles` and `@primeuix/themes` installed (optional peers). Options — `preset`, `darkModeSelector`, `cssLayer` — are on [Use PrimeReact's styled mode](../Styling/themed.md).
+
 ## Props
 
 ### `value`
@@ -59,8 +76,9 @@ The most useful members:
 | `pt` | Per-component pass-through configuration. Keys are PrimeReact component names (`button`, `dialog`, `inputtext`, …); values are slot configuration objects. |
 | `ptOptions` | Controls merge vs. replace behavior for `pt`. Default is `{ mergeSections: true }` which merges per-instance `pt` with the global preset. |
 | `inputVariant` | `'outlined'` or `'filled'` — switches the default input rendering across the whole app. |
-| `theme` | `{ preset, options }` — opt into a styled `@primeuix/themes` preset (e.g. `import Aura from '@primeuix/themes/aura'`). A PrimeUI `license` key is required whether or not you apply a preset — the check runs when the provider mounts. |
-| `license` | Your PrimeUI license key, passed straight through to PrimeReact. Required for the styled `@primeuix/themes` presets — see [Styling](../Styling/index.md). |
+| `theme` | `{ preset, options }` — a `@primeuix/themes` preset and its options (`darkModeSelector`, `cssLayer`, …). Emits the `--p-*` design tokens; on its own it paints nothing, because the primitives carry no `p-*` class — pair it with `defaults`, which is what `styledMode()` does. |
+| `defaults` | Default props per PrimeReact component name. `styledMode()` uses it to hand every primitive PrimeReact's component styles (`primeReactStyles`), which is what puts the `p-*` class names on the elements the preset paints. |
+| `license` | Your PrimeUI license key, passed straight through to PrimeReact. Required whichever way you style — the check runs when the provider mounts — see [Styling](../Styling/index.md). |
 | `ripple` | Enables PrimeReact's ripple animation on supported components. |
 | `zIndex` | Per-overlay-type z-index baseline (`{ modal: 1100, overlay: 1000, menu: 1000, tooltip: 1100 }`). |
 | `locale` | PrimeReact locale string. |
@@ -121,5 +139,6 @@ const merged = mergeCratisComponentsConfig({ unstyled: true, pt: myPt });
 ## See also
 
 - [Styling Overview](../Styling/index.md) — the supported styling options and where the provider fits
+- [Use PrimeReact's styled mode](../Styling/themed.md) — `styledMode()`, `CratisPreset` and the options
 - [Pass-through cheat sheet](../Styling/pass-through.md) — what `pt` reaches in each Cratis wrapper
 - [Use fully unstyled mode](../Styling/unstyled.md) — full `pt` preset walk-through

--- a/Documentation/Dropdown/index.md
+++ b/Documentation/Dropdown/index.md
@@ -38,6 +38,8 @@ function MyForm() {
 }
 ```
 
+No `optionLabel` / `optionValue` here: when the option objects carry `label` and `value`, those are used — the PrimeReact 10 `Dropdown` convention.
+
 ## Props
 
 `Dropdown` exposes a wrapper-owned surface — the common single/multi select props every Cratis form needs — rather than leaking PrimeReact's entire Select API. For anything beyond this, use `pt` / `ptOptions` / `unstyled`.
@@ -46,8 +48,8 @@ function MyForm() {
 interface DropdownProps<T = unknown> {
     value?: T;
     options?: unknown[];
-    optionLabel?: string;                       // property used as the visible label
-    optionValue?: string;                       // property used as the underlying value
+    optionLabel?: string;                       // property used as the visible label; defaults to 'label' when the options carry it
+    optionValue?: string;                       // property used as the underlying value; defaults to 'value' when the options carry it
     placeholder?: string;
     filter?: boolean;                           // filter input inside the popup
     multiple?: boolean;                         // multi-select
@@ -70,7 +72,7 @@ interface DropdownProps<T = unknown> {
 }
 ```
 
-Every prop is optional, and the wrapper declares no defaults of its own — `multiple`, `filter`, `showClear`, `invalid` and `disabled` are simply off unless you set them.
+Every prop is optional. `multiple`, `filter`, `showClear`, `invalid` and `disabled` are simply off unless you set them. The one convention the wrapper applies is `optionLabel` / `optionValue`: when they are omitted and the options are objects carrying a `label` / `value` field, that field is used — as PrimeReact 10's `Dropdown` did. v11's `Select` compares the option object itself against the value otherwise, so `[{ label, value }]` options with a scalar `value` would never match without it. Options keyed differently (`name` / `code`, say) still need `optionLabel` / `optionValue` spelled out.
 
 There is no `...rest` spread and no index signature, so anything not listed above is a compile error rather than an ignored prop. That includes `aria-*` beyond the two declared (`aria-label`, `aria-labelledby`) and PrimeReact Select props the wrapper deliberately does not surface — `appendTo`, `variant`, `size`, `fluid`, `filterMatchMode`, `optionGroupLabel` / `optionGroupChildren`, `optionDisabled`, `open` / `defaultOpen`, and the rest. Reach those through `pt` / `ptOptions` / `unstyled`, or compose `Select` yourself.
 
@@ -99,6 +101,8 @@ const options = ['React', 'Angular', 'Vue', 'Svelte'];
 ```
 
 ### Object Options
+
+Options shaped `{ label, value }` need nothing more (see the quick start). Any other shape names its fields:
 
 ```typescript
 const countries = [
@@ -378,7 +382,7 @@ There is no `panelClassName` — the popup is styled through `pt`, whose slot na
 />
 ```
 
-Global CSS is possible too, but not through `p-*` class names. PrimeReact 11 is unstyled-first: with no `@primeuix/themes` preset applied its elements carry **no `p-*` class at all**, and parts are identified by data attributes instead:
+Global CSS is possible too, but outside [PrimeReact's styled mode](../Styling/themed.md) not through `p-*` class names. PrimeReact 11 is unstyled-first: its primitives carry **no `p-*` class at all** unless `styledMode()` hands them PrimeReact's component styles, and parts are identified by data attributes instead:
 
 ```css
 [data-scope='select'][data-part='root'] {

--- a/Documentation/Styling/baseline-theme.md
+++ b/Documentation/Styling/baseline-theme.md
@@ -1,6 +1,6 @@
 # Use the Cratis baseline theme
 
-PrimeReact 11 is unstyled-first, and its styled `@primeuix/themes` presets need a PrimeUI license. If you want a polished default look **without a license**, ship the components unstyled and import the **Cratis baseline theme** — a token-based stylesheet that skins every component from the `--cratis-*` layer.
+PrimeReact 11 is unstyled-first, and [its styled mode](themed.md) needs two more packages — `@primereact/styles` and `@primeuix/themes`. If you want a polished default look **without them**, ship the components unstyled and import the **Cratis baseline theme** — a token-based stylesheet that skins every component from the `--cratis-*` layer. (A PrimeUI license key is still required to run PrimeReact 11 itself — see [Licensing](../migration.md#licensing).)
 
 ## Setup
 
@@ -36,7 +36,7 @@ Add the `cratis-dark` class to an ancestor for the dark palette:
 
 ## Layering under a preset
 
-The baseline theme defers to a `@primeuix/themes` preset's `--p-*` tokens when one is present, so you can also run it underneath a licensed preset — the preset drives the palette and the baseline theme fills the gaps.
+The baseline theme defers to a `@primeuix/themes` preset's `--p-*` tokens when one is present, so you can also run it underneath [styled mode](themed.md) — the preset drives the palette and the baseline theme fills the gaps. `styledMode()`'s dark scheme keys off the same `.cratis-dark` class by default, so one class switches both.
 
 ## Overriding
 
@@ -51,5 +51,5 @@ The baseline theme also maps the `--color-*` token family that `@cratis/arc.reac
 
 ## When this is the wrong fit
 
-- You want one of PrimeReact's prebuilt design systems (Aura, Lara, …) — [use a preset](./themed.md) instead.
+- You want PrimeReact's own look — one of its design systems (Aura, Lara, …) painted by PrimeReact's component styles — [use styled mode](./themed.md) instead.
 - You have a strict design system to honor — go [fully unstyled](./unstyled.md) with your own `pt`.

--- a/Documentation/Styling/cratis-tokens.md
+++ b/Documentation/Styling/cratis-tokens.md
@@ -7,17 +7,17 @@ The `--cratis-*` CSS variable layer is the Cratis-scoped tint surface every Crat
 /*                            ^ v11 (@primeuix/themes)      ^ v10 legacy      */
 ```
 
-`@cratis/components` 3.0 requires `primereact@^11` as a peer, so the **v11 arm is the one that resolves in a correctly installed app**. The v10 arm is kept deliberately for the upgrade window, when an app still has a compiled v10 theme stylesheet on the page while it ports its own screens. Nothing breaks the day that stylesheet is removed — the v11 arm was already winning.
+`@cratis/components` 3.0 requires `primereact@^11` as a peer, so the **v11 arm is the one that resolves in a correctly installed app**. The v10 arm is kept deliberately for the upgrade window, when an app still has a compiled v10 theme stylesheet on the page while it ports its own screens — or imports [`@cratis/components/primereact-v10-palette`](../migration.md#theming-without-a-theme-stylesheet), which restores those v10 names for CSS already written against them. Nothing breaks the day that stylesheet is removed — the v11 arm was already winning.
 
 This indirection is the single seam that insulates your code (and your consumers' `--cratis-*` overrides) from PrimeReact's token system changing underneath you. It is the reason this library could span a PrimeReact major version at all.
 
-You override `--cratis-*` tokens when you want **just** Cratis-scoped surfaces (validation error text, FormElement addon, breadcrumb borders, …) tinted independently of PrimeReact widgets. To repaint PrimeReact widgets themselves, customize the preset — see [the custom palette setup](custom-palette.md).
+You override `--cratis-*` tokens when you want **just** Cratis-scoped surfaces (validation error text, FormElement addon, breadcrumb borders, …) tinted independently of PrimeReact widgets. To repaint PrimeReact widgets themselves, override the tokens under the baseline theme or derive your own preset in styled mode — see [the custom palette setup](custom-palette.md).
 
 ## Where the values come from
 
 PrimeReact 11 ships **zero CSS**, so nothing populates `--p-*` until something does it at runtime. Two things can:
 
-- **A `@primeuix/themes` preset.** A preset is a plain JavaScript token object; `@primeuix/styled` turns it into `--p-*` custom properties when you hand it to the provider (`value={{ theme: { preset: Aura } }}`). This path is [license-gated](themed.md).
+- **A `@primeuix/themes` preset**, in [PrimeReact's styled mode](themed.md). A preset is a plain JavaScript token object; `@primeuix/styled` turns it into `--p-*` custom properties when the provider receives it. `styledMode()` from `@cratis/components/styled` hands the provider the preset together with PrimeReact's component styles — the tokens alone would populate `--p-*` (and so `--cratis-*`) but paint no widget, because the primitives carry no `p-*` class without those styles.
 - **The [Cratis baseline theme](baseline-theme.md).** `@cratis/components/theme` skips `--p-*` entirely and assigns the `--cratis-*` tokens concrete values directly, light and dark — no preset needed. It still defers to a preset's `--p-*` when one is present.
 
 With neither, the tokens resolve to nothing and the rules that read them no-op. That is deliberate: the library stays theme-agnostic rather than imposing a default palette on consumers.
@@ -167,11 +167,11 @@ The Cratis token layer is **additive** on top of PrimeReact's theme system, not 
 
 That means:
 
-- Repaint PrimeReact itself — customize the preset with `definePreset` so the `--p-*` tokens change — and both PrimeReact widgets *and* Cratis surfaces follow. (During an upgrade window, a still-loaded v10 theme's legacy `--surface-*` / `--text-color` variables reach the Cratis surfaces the same way, through the fallback arm.)
+- Repaint PrimeReact itself — in styled mode, derive the preset with `definePreset` so the `--p-*` tokens change — and both PrimeReact widgets *and* Cratis surfaces follow. (During an upgrade window, a still-loaded v10 theme's legacy `--surface-*` / `--text-color` variables — or the ones `@cratis/components/primereact-v10-palette` restores — reach the Cratis surfaces the same way, through the fallback arm.)
 - Override `--cratis-surface-card` → only Cratis surfaces follow; PrimeReact widgets keep their existing color.
 - Under the [Cratis baseline theme](baseline-theme.md) the distinction collapses: the theme skins the widgets from the same `--cratis-*` tokens, so one override repaints both.
 
-Use the preset when you want a whole-UI repaint. Use the Cratis token when you want a Cratis-specific accent that differs from PrimeReact widgets.
+Use the preset (styled mode) or the baseline theme's tokens when you want a whole-UI repaint. Use the Cratis token when you want a Cratis-specific accent that differs from PrimeReact widgets.
 
 ## See also
 

--- a/Documentation/Styling/custom-palette.md
+++ b/Documentation/Styling/custom-palette.md
@@ -5,7 +5,7 @@ You want a theme's chrome — its dialog frames, button shapes, focus rings, inp
 This setup keeps a theme as the **structural baseline** and repaints it with your palette. Which knob you turn depends on which theme you started from:
 
 - **[Cratis baseline theme](baseline-theme.md)** — override the `--cratis-*` tokens in CSS.
-- **[`@primeuix/themes` preset](themed.md)** (license) — customize the preset's design tokens with `definePreset`.
+- **[PrimeReact's styled mode](themed.md)** (license, `@primereact/styles` + `@primeuix/themes`) — derive your own preset from `CratisPreset` with `definePreset` and hand it to `styledMode({ preset })`.
 
 Either way the `--cratis-*` layer follows your palette, so Cratis-scoped surfaces stay in sync.
 
@@ -55,16 +55,16 @@ import './palette.override.css';   // after the theme so it wins
 }
 ```
 
-## With a `@primeuix/themes` preset (`definePreset`)
+## In PrimeReact's styled mode (`definePreset`)
 
-Presets are customized in TypeScript, not CSS: derive a new preset from a base one with `definePreset` and hand it to the provider. Design-token references like `{sky.500}` point at the preset's built-in primitive palette:
+Presets are customized in TypeScript, not CSS: derive a new preset from a base one with `definePreset` and hand it to `styledMode()`, which pairs it with PrimeReact's component styles so the widgets are actually painted (a preset alone emits `--p-*` tokens but styles nothing — see [styled mode](themed.md)). Start from `CratisPreset` to keep the PrimeReact 10 look of Cratis applications, or from any `@primeuix/themes` preset. Design-token references like `{sky.500}` point at the preset's built-in primitive palette:
 
 ```ts
 // brand-preset.ts
 import { definePreset } from '@primeuix/themes';
-import Aura from '@primeuix/themes/aura';
+import { CratisPreset } from '@cratis/components/styled';
 
-export const BrandPreset = definePreset(Aura, {
+export const BrandPreset = definePreset(CratisPreset, {
     semantic: {
         primary: {
             50: '{sky.50}',   100: '{sky.100}', 200: '{sky.200}',
@@ -78,14 +78,17 @@ export const BrandPreset = definePreset(Aura, {
 
 ```tsx
 import { CratisComponentsProvider } from '@cratis/components';
+import { styledMode } from '@cratis/components/styled';
 import { BrandPreset } from './brand-preset';
 
 export const App = () => (
-    <CratisComponentsProvider value={{ theme: { preset: BrandPreset }, license: 'YOUR-PRIMEUI-KEY' }}>
+    <CratisComponentsProvider value={{ license: 'YOUR-PRIMEUI-KEY', ...styledMode({ preset: BrandPreset }) }}>
         <YourApp />
     </CratisComponentsProvider>
 );
 ```
+
+Dark mode follows `styledMode()`'s `darkModeSelector` — `.cratis-dark` by default, the same class the baseline theme uses — so the preset's dark scheme and the `--cratis-*` tokens switch together.
 
 ## Scoped overrides
 
@@ -144,7 +147,7 @@ The baseline theme's own `cratis-dark` class is the simplest light/dark switch w
 
 Two override surfaces are available, with different reach:
 
-- **The theme's palette** (`--cratis-*` for the baseline theme, or the preset's `--p-*` design tokens) — read by the widgets. Override these to repaint the whole UI.
+- **The theme's palette** (`--cratis-*` for the baseline theme, or the preset's `--p-*` design tokens in styled mode) — read by the widgets. Override these to repaint the whole UI.
 - **`--cratis-*` tokens on a Cratis-only scope** — read by Cratis-scoped surfaces (validation errors, the FormElement addon, breadcrumb borders, etc.). Override these when you want Cratis surfaces to differ from the surrounding widgets.
 
 See [Cratis token reference](cratis-tokens.md) for the full Cratis token list, and [Pass-through cheat sheet](pass-through.md) when you want even tighter per-component control.

--- a/Documentation/Styling/getting-started.md
+++ b/Documentation/Styling/getting-started.md
@@ -18,6 +18,7 @@ Two more notes:
 
 - `primeicons` went **7 → 8** alongside PrimeReact 11.
 - `primereact` pins `@primereact/core` and `@primereact/headless` to its own exact version, so all three land on the same release. Declaring them anyway is what makes a strict installer (pnpm, Yarn PnP) resolve them for the library too.
+- `@primereact/styles` and `@primeuix/themes` are **optional** peers — install them only for [PrimeReact's styled mode](themed.md). The baseline theme and unstyled mode need neither.
 
 The heavier extras (`pixi.js` for `PivotViewer`, `framer-motion` for animated panels, `allotment` for the `DataPage` resizable layout) are still regular dependencies, so they come down with the package and modern bundlers tree-shake away the ones you never import. The remaining peers — `react`/`react-dom` 19+, `@cratis/arc*`, `reflect-metadata`, and `tsyringe` — already come with your Arc frontend.
 
@@ -39,7 +40,7 @@ Import them in that order: `styles` and `theme` both consume the tokens.
 
 ## Wire the provider
 
-Mount [`CratisComponentsProvider`](../Common/cratis-components-provider.md) once at the root of your tree. The provider is a thin wrapper around PrimeReact's own `PrimeReactProvider` and is where you configure `unstyled`, `pt`, `ptOptions`, `inputVariant`, `ripple`, `zIndex`, `locale`, `theme` and `license` — all through its single `value` prop:
+Mount [`CratisComponentsProvider`](../Common/cratis-components-provider.md) once at the root of your tree. The provider is a thin wrapper around PrimeReact's own `PrimeReactProvider` and is where you configure `unstyled`, `pt`, `ptOptions`, `inputVariant`, `ripple`, `zIndex`, `locale`, `theme`, `defaults` and `license` — all through its single `value` prop:
 
 ```tsx
 import '@cratis/components/tokens';
@@ -64,7 +65,7 @@ With nothing else, you've imported:
 That's enough for the wrappers to render structurally, but PrimeReact 11 is **unstyled-first**: widgets need a look applied before they resemble anything other than raw browser primitives. Choose the setup that matches how much visual control you need:
 
 - [Use the Cratis baseline theme](baseline-theme.md) — the default look, no preset needed
-- [Use a PrimeReact theme](themed.md) — a styled `@primeuix/themes` preset
+- [Use PrimeReact's styled mode](themed.md) — `styledMode()`: a `@primeuix/themes` preset plus PrimeReact's own component styles
 - [Use a custom palette on top of a theme](custom-palette.md) — keep the theme's structure and supply your colors
 - [Use fully unstyled mode](unstyled.md) — bring every visual yourself through `pt` / CSS
 

--- a/Documentation/Styling/index.md
+++ b/Documentation/Styling/index.md
@@ -4,7 +4,7 @@
 > **PrimeReact 11 is not MIT.**
 > `@cratis/components` is MIT, but as of 3.0.0 it builds on **PrimeReact 11**, which is part of
 > PrimeTek's commercial **PrimeUI** family — as are `primeicons` 8.x, `@primereact/core`,
-> `@primereact/headless`, `@primeuix/themes` and `@primeuix/styled`. PrimeReact 10 was MIT; 11 is not.
+> `@primereact/headless`, `@primereact/styles`, `@primeuix/themes` and `@primeuix/styled`. PrimeReact 10 was MIT; 11 is not.
 >
 > A **PrimeUI license key is required regardless of how you style** — the check runs when
 > `PrimeReactProvider` mounts, not when a theme is applied. Without one you get a console warning and
@@ -18,7 +18,7 @@
 > Need to stay MIT-only? **`@cratis/components` 2.x remains on PrimeReact 10.** See
 > [Licensing](/components/migration/#licensing).
 
-Cratis Components is built on top of PrimeReact 11 and stays out of your way when it comes to styling. PrimeReact 11 is **unstyled-first** — it ships no widget chrome by default — so you decide the look: apply a ready-made theme, keep a theme's structure while painting your own palette, or take complete control and provide every visual yourself — all without forking the library or fighting it.
+Cratis Components is built on top of PrimeReact 11 and stays out of your way when it comes to styling. PrimeReact 11 is **unstyled-first** — it ships no widget chrome by default — so you decide the look: use the Cratis baseline theme, run PrimeReact's own styled mode, keep a theme's structure while painting your own palette, or take complete control and provide every visual yourself — all without forking the library or fighting it.
 
 The supported styling setups are not mutually exclusive: every component still exposes the same building blocks, so you can combine them per-component or per-region of your app.
 
@@ -27,40 +27,46 @@ The supported styling setups are not mutually exclusive: every component still e
 | Setup | When | Effort | What you write |
 |---|---|---|---|
 | [**Cratis baseline theme**](baseline-theme.md) | You want a polished default look with no extra dependency. | Lowest | `import '@cratis/components/theme'` + `class="cratis-theme"` |
-| [**A `@primeuix/themes` preset**](themed.md) | You want one of PrimeReact's design systems and have a PrimeUI license key. | Low | A preset via `value={{ theme: { preset } }}` (+ a `license` key) |
-| [**A custom palette on top of a theme**](custom-palette.md) | You want a theme's structure but your own colors. | Low | A theme + `--cratis-*` (or preset) token overrides |
+| [**PrimeReact's styled mode**](themed.md) | You want PrimeReact's own look — a `@primeuix/themes` preset painting PrimeReact's component styles — and have a PrimeUI license key. | Low | `...styledMode()` from `@cratis/components/styled` in the provider `value` (+ a `license` key); install `@primereact/styles` and `@primeuix/themes` |
+| [**A custom palette on top of a theme**](custom-palette.md) | You want a theme's structure but your own colors. | Low | `--cratis-*` overrides on the baseline theme, or `styledMode({ preset: definePreset(CratisPreset, …) })` |
 | [**Fully unstyled mode**](unstyled.md) | You're integrating into a tightly controlled design system. | Highest | `unstyled: true` + a `pt` preset in CSS or Tailwind |
 
 Every setup shares the same install and stylesheet imports described in [Getting Started](getting-started.md). You can change direction later because the same provider, tokens, and `pt` hooks stay available.
 
 ## Why the themed options need a theme
 
-**PrimeReact 11 ships zero CSS.** There is no `primereact/resources/themes/*.css` any more — the v10 theme stylesheets do not exist, and there is nothing to `<link>` or `import`. On its own PrimeReact supplies **no** widget chrome at all: no padding, borders, dialog frame, focus rings, or button shapes. It also emits no `p-*` class names when nothing is applied; parts are identified by data attributes instead (`[data-scope="dialog"][data-part="close"]`).
+**PrimeReact 11 ships zero CSS.** There is no `primereact/resources/themes/*.css` any more — the v10 theme stylesheets do not exist, and there is nothing to `<link>` or `import`. The `primereact` package is **unstyled primitives**: on its own it supplies **no** widget chrome at all — no padding, borders, dialog frame, focus rings, or button shapes — and its elements carry **no `p-*` class names**; parts are identified by data attributes instead (`[data-scope="dialog"][data-part="close"]`). The `p-*` class names and the CSS behind them live in a separate package, `@primereact/styles`, and PrimeReact's own styled components (`@primereact/ui`) are simply the primitives with those styles preset. `@cratis/components` builds on the primitives.
 
-So every setup except fully-unstyled starts from a theme, and that chrome comes from one of two license-relevant sources:
+That has one consequence worth stating plainly: **a `@primeuix/themes` preset by itself styles nothing here.** Handing the provider `theme: { preset }` emits the `--p-*` design tokens at runtime, but with no `p-*` class on any element the preset has nothing to paint.
 
-- the **Cratis baseline theme** (`import '@cratis/components/theme'` + `class="cratis-theme"`) — a token-based default look that needs no `@primeuix/themes` dependency.
-- a `@primeuix/themes` **preset** — Aura, Lara, Nora. Applying one requires a **PrimeUI license key** (a free community tier or a paid one); without it PrimeReact shows an "Invalid PrimeUI License" banner in development *and* production.
+So every setup except fully-unstyled starts from a theme, and that chrome comes from one of two sources:
+
+- the **Cratis baseline theme** (`import '@cratis/components/theme'` + `class="cratis-theme"`) — a token-based default look that needs no `@primereact/styles` or `@primeuix/themes` dependency.
+- **PrimeReact's styled mode** — `styledMode()` from `@cratis/components/styled`, spread into the provider `value`. It supplies a `@primeuix/themes` preset (default `CratisPreset`; Aura, Lara, Nora, or a `definePreset` result all work) **and** `primeReactStyles`, PrimeReact's own component styles, which the provider applies to every primitive rendered under it — the ones this library renders and the ones your application renders itself. That is what makes the `p-*` class names appear and the preset paint them. It needs `@primereact/styles` and `@primeuix/themes` installed (both optional peers).
+
+Either way, a **PrimeUI license key** is required — the check runs when the provider mounts, whichever look you choose (a free community tier or a paid one); without it PrimeReact shows an "Invalid PrimeUI License" banner in development *and* production.
 
 Without either — and without your own `pt` / CSS — components render as the raw HTML primitives the browser supplies by default.
 
-The `--cratis-*` token layer is an additive Cratis-scoped tint for surfaces the wrappers in this package own — validation error text, the FormElement addon background, breadcrumb borders — and **is not, by itself, sufficient to skin PrimeReact widgets**. Customize the active preset (via `@primeuix/themes` `definePreset`) when you want the whole UI in your palette. Use `unstyled: true` and a `pt` preset when you want to replace PrimeReact's visuals entirely.
+The `--cratis-*` token layer is an additive Cratis-scoped tint for surfaces the wrappers in this package own — validation error text, the FormElement addon background, breadcrumb borders — and **is not, by itself, sufficient to skin PrimeReact widgets**. In styled mode, derive your own preset (`definePreset(CratisPreset, …)`) when you want the whole UI in your palette; under the baseline theme, override the `--cratis-*` tokens. Use `unstyled: true` and a `pt` preset when you want to replace PrimeReact's visuals entirely.
 
 ## Mental model
 
-Every component you import from `@cratis/components` is a thin wrapper around a PrimeReact component plus a few Cratis additions (validation hooks, command-form integration, …). The important thing to understand about v11 is that a preset is **JavaScript, not CSS** — a plain token object that `@primeuix/styled` turns into `--p-*` custom properties **at runtime**, when you hand it to the provider. So the chain runs:
+Every component you import from `@cratis/components` is a thin wrapper around a PrimeReact primitive plus a few Cratis additions (validation hooks, command-form integration, …). The important thing to understand about v11 is that a theme is **JavaScript, not CSS**, and comes in two halves: a preset — a plain token object that `@primeuix/styled` turns into `--p-*` custom properties **at runtime**, when you hand it to the provider — and PrimeReact's component styles, which put the `p-*` class names on the primitives and carry the CSS those tokens drive. So the chain runs:
 
 ```mermaid
 flowchart LR
     Preset["preset (JS)<br/>@primeuix/themes"] -->|"@primeuix/styled, at runtime"| P["--p-* custom properties"]
     P --> C["--cratis-* tokens<br/>tokens.css — the seam"]
     C --> CSS["component CSS"]
+    Styles["primeReactStyles<br/>@primereact/styles, via provider defaults"] -->|"p-* class names + PrimeReact component CSS"| W["PrimeReact widgets"]
+    P --> W
     Theme["@cratis/components/theme<br/>(no preset)"] -.->|"assigns --cratis-* directly"| C
 ```
 
-Read as three layers you can intervene at:
+`styledMode()` hands the provider both the preset and `primeReactStyles`. Read as three layers you can intervene at:
 
-1. **PrimeReact design tokens** — the `--p-*` custom properties emitted at runtime from a `@primeuix/themes` preset, customized via `definePreset`. Read directly by PrimeReact widgets. Customize the preset to repaint the whole UI.
+1. **PrimeReact design tokens** — the `--p-*` custom properties emitted at runtime from a `@primeuix/themes` preset, customized via `definePreset`. Read by PrimeReact's component CSS, which reaches the widgets through the `p-*` class names `primeReactStyles` puts on them. Derive your own preset to repaint the whole UI — in styled mode.
 2. **Cratis tokens** — `--cratis-surface-card`, `--cratis-text-color`, `--cratis-primary-color`, … Read only by Cratis-scoped surfaces. In `tokens.css` each resolves the v11 design token first (e.g. `--p-content-border-color`) and falls back to the legacy v10 variable, which is what keeps a half-ported app working during its upgrade window. With the baseline theme instead of a preset, `@cratis/components/theme` assigns these tokens concrete values directly — light and dark — and defers to a preset's `--p-*` when one *is* present. Override them when you want a Cratis surface tinted differently from the surrounding PrimeReact widgets.
 3. **PrimeReact `pt` (pass-through)** — A per-component prop that lets you attach CSS class names (or inline styles) to every slot inside a PrimeReact widget. The strongest customization knob; works hand-in-hand with `unstyled` mode.
 
@@ -70,7 +76,7 @@ The [Cratis token reference](cratis-tokens.md) lists every token and the surface
 
 - [Getting Started](getting-started.md) — the install, stylesheet imports, and provider every option shares
 - [Use the Cratis baseline theme](baseline-theme.md) — the default look, no preset needed
-- [Use a PrimeReact theme](themed.md) — a `@primeuix/themes` preset (needs a license)
+- [Use PrimeReact's styled mode](themed.md) — `styledMode()`: a `@primeuix/themes` preset plus PrimeReact's component styles (needs a license)
 - [Use a custom palette on top of a theme](custom-palette.md)
 - [Use fully unstyled mode](unstyled.md)
 - [Cratis token reference](cratis-tokens.md)

--- a/Documentation/Styling/mixing-paths.md
+++ b/Documentation/Styling/mixing-paths.md
@@ -4,13 +4,13 @@ The three styling options compose. You don't have to choose one for the whole ap
 
 ## Themed app with one unstyled island
 
-Keep a styled `@primeuix/themes` preset as your global baseline and opt one specific component out with the per-instance `unstyled` prop:
+Keep [PrimeReact's styled mode](themed.md) as your global baseline and opt one specific component out with the per-instance `unstyled` prop:
 
 ```tsx
 import '@cratis/components/tokens';
 import '@cratis/components/styles';
-import Aura from '@primeuix/themes/aura';
 import { CratisComponentsProvider } from '@cratis/components';
+import { styledMode } from '@cratis/components/styled';
 import { Dialog } from '@cratis/components/Dialogs';
 
 const brandDialogPt = {
@@ -20,10 +20,10 @@ const brandDialogPt = {
 };
 
 export const App = () => (
-    <CratisComponentsProvider value={{ theme: { preset: Aura }, license: 'YOUR-PRIMEUI-KEY' }}>
+    <CratisComponentsProvider value={{ license: 'YOUR-PRIMEUI-KEY', ...styledMode() }}>
         <YourApp />
 
-        {/* This one Dialog opts out of the preset and uses its own brand visuals. */}
+        {/* This one Dialog opts out of the theme and uses its own brand visuals. */}
         <Dialog title="Brand callout" unstyled pt={brandDialogPt}>
             …
         </Dialog>
@@ -56,7 +56,7 @@ export const App = () => (
 
 ## App-wide dark mode
 
-With the Cratis baseline theme, dark mode is a single class: add `cratis-dark` alongside `cratis-theme` for the dark palette, remove it for light. The widgets and Cratis-scoped surfaces both follow because the baseline theme drives everything from the `--cratis-*` tokens:
+With the Cratis baseline theme, dark mode is a single class: add `cratis-dark` alongside `cratis-theme` for the dark palette, remove it for light. The widgets and Cratis-scoped surfaces both follow because the baseline theme drives everything from the `--cratis-*` tokens. The same class switches PrimeReact's styled mode too — `styledMode()`'s `darkModeSelector` defaults to `.cratis-dark` (pass `'system'` to follow `prefers-color-scheme` instead):
 
 ```tsx
 const ThemeToggle = () => {
@@ -113,7 +113,7 @@ Token overrides cascade, so any ancestor scope works for tinting Cratis-scoped s
 </div>
 ```
 
-With the baseline theme these `--cratis-*` overrides already reach the widgets in the region — the theme reads the same tokens. (On a `@primeuix/themes` preset, region-scoped widget colors come from `definePreset` instead; the `--cratis-*` overrides still retint the Cratis-scoped surfaces.)
+With the baseline theme these `--cratis-*` overrides already reach the widgets in the region — the theme reads the same tokens. (In styled mode, region-scoped widget colors come from the preset instead — `definePreset(CratisPreset, …)`; the `--cratis-*` overrides still retint the Cratis-scoped surfaces.)
 
 ## Per-component visual override inside unstyled mode
 
@@ -139,11 +139,11 @@ import './custom-table.css';
 
 - **Provider value updates re-render**: changing `value` on `CratisComponentsProvider` rebuilds the merged config. Use a stable reference (e.g. `useMemo` or a module-level constant) to avoid spurious re-renders.
 - **`pt` merging is deep**: PrimeReact merges global `pt` with per-instance `pt` by default. Set `ptOptions={{ mergeSections: false }}` on the wrapper if you need a hard replace.
-- **Where `--cratis-*` reaches depends on the theme**: with the Cratis baseline theme the widgets read those tokens, so an override repaints both. On a `@primeuix/themes` preset the widgets read `--p-*` design tokens, so `--cratis-*` overrides only retint the Cratis-scoped surfaces — repaint the widgets with `definePreset`. See [Cratis token reference](cratis-tokens.md).
+- **Where `--cratis-*` reaches depends on the theme**: with the Cratis baseline theme the widgets read those tokens, so an override repaints both. In styled mode the widgets read the preset's `--p-*` design tokens, so `--cratis-*` overrides only retint the Cratis-scoped surfaces — repaint the widgets with a `definePreset` derivative handed to `styledMode({ preset })`. See [Cratis token reference](cratis-tokens.md).
 
 ## See also
 
-- [Use a PrimeReact theme](themed.md)
+- [Use PrimeReact's styled mode](themed.md)
 - [Use a custom palette on top of a PrimeReact theme](custom-palette.md)
 - [Use fully unstyled mode](unstyled.md)
 - [Pass-through cheat sheet](pass-through.md)

--- a/Documentation/Styling/themed.md
+++ b/Documentation/Styling/themed.md
@@ -1,31 +1,80 @@
-# Use a PrimeReact theme
+# Use PrimeReact's styled mode
 
-You want components to look reasonable out of the box using one of PrimeReact's own design systems. PrimeReact 11 ships zero CSS and is unstyled-first, so a *theme* is no longer a stylesheet you import — it is a **`@primeuix/themes` preset**, a plain JavaScript token object that `@primeuix/styled` turns into `--p-*` custom properties at runtime when you hand it to the provider.
+You want components to look the way PrimeReact's own do — one of its design systems, painted by a `@primeuix/themes` preset. PrimeReact 11 ships zero CSS and is unstyled-first, so a *theme* is no longer a stylesheet you import. It is two things handed to the provider at runtime: a **preset** (a plain JavaScript token object that `@primeuix/styled` turns into `--p-*` custom properties) and PrimeReact's **component styles** (`@primereact/styles`, the `p-*` class names and the CSS the preset drives). `styledMode()` from `@cratis/components/styled` supplies both.
 
-> **Licensing.** A **PrimeUI license key** is required to run PrimeReact 11 at all — applying a preset does not change that, and neither does going unstyled. See [Licensing](../migration.md#licensing). What a preset *does* add is a dependency on `@primeuix/themes`; the [Cratis baseline theme](baseline-theme.md) gives a polished look without it.
+> [!IMPORTANT]
+> **A preset alone styles nothing.** PrimeReact 11's `primereact` package is unstyled primitives: they render structural markup identified by `data-scope` / `data-part` attributes and **no `p-*` class names**. Handing the provider `theme: { preset }` by itself emits the `--p-*` tokens, but with no class names on the elements the preset has nothing to paint. PrimeReact's own styled components (`@primereact/ui`) are just the primitives with their `styles` prop preset from `@primereact/styles` — and `@cratis/components` builds on the primitives, so it needs the same gluing. That is what `styledMode()` does.
+
+**Licensing.** A **PrimeUI license key** is required to run PrimeReact 11 at all — styled mode does not change that, and neither does going unstyled. See [Licensing](../migration.md#licensing). What styled mode *does* add is two dependencies, `@primereact/styles` and `@primeuix/themes`; the [Cratis baseline theme](baseline-theme.md) gives a polished look without them.
 
 ## Setup
 
-Install `@primeuix/themes`, pick a preset, and pass it — together with your license key — through the provider's single `value` prop. The preset paints PrimeReact's own widgets, and the `--cratis-*` tokens follow the preset so Cratis-scoped surfaces stay in sync:
+Install the two packages styled mode needs — both are optional peers of `@cratis/components` — and spread `styledMode()` into the provider's `value`, next to your license key:
+
+```bash
+npm install @primereact/styles @primeuix/themes
+```
 
 ```tsx
 import '@cratis/components/tokens';
 import '@cratis/components/styles';
-import Aura from '@primeuix/themes/aura';
 import { CratisComponentsProvider } from '@cratis/components';
+import { styledMode } from '@cratis/components/styled';
 
 export const App = () => (
-    <CratisComponentsProvider value={{ theme: { preset: Aura }, license: 'YOUR-PRIMEUI-KEY' }}>
+    <CratisComponentsProvider value={{ license: 'YOUR-PRIMEUI-KEY', ...styledMode() }}>
         <YourApp />
     </CratisComponentsProvider>
 );
 ```
 
-Presets ship in the `@primeuix/themes` package — Aura, Lara, Nora, and Material — each customizable with `definePreset`. `npm i @primeuix/themes` for this path only; it is not a peer dependency of `@cratis/components`. Without a license key, PrimeReact logs a warning and shows an "Invalid PrimeUI License" banner in development **and** production.
+`styledMode()` returns `{ theme, defaults }`:
+
+- **`theme`** — a `@primeuix/themes` preset plus its options. The default preset is **`CratisPreset`**: Lara, with the blue primary and gray surfaces of PrimeReact 10's `lara-light-blue` / `lara-dark-blue`, and, in the dark scheme, content and overlays one step lighter than the page — the dark surface scale sits one step lighter than the light one, so Lara's own tokens land on the tones those themes used. Both color schemes are carried.
+- **`defaults`** — `primeReactStyles`, PrimeReact's own component styles keyed by primitive name. The provider applies them to **every** primitive rendered under it — the ones this library renders *and* the ones your application renders itself — so the `p-*` class names appear and the preset paints them.
+
+The `--cratis-*` tokens follow the preset's `--p-*` tokens, so Cratis-scoped surfaces stay in sync with the widgets. Without a license key, PrimeReact logs a warning and shows an "Invalid PrimeUI License" banner in development **and** production.
+
+### Options
+
+| Option | Default | What it does |
+|---|---|---|
+| `preset` | `CratisPreset` | Any `@primeuix/themes` preset — Aura, Lara, Nora, Material — or one derived with `definePreset`. |
+| `darkModeSelector` | `cratisDarkModeSelector` (`.cratis-dark`) | How the dark scheme is activated: a selector, `'system'` for `prefers-color-scheme`, or `'none'` to stay light. The default is the class the Cratis baseline theme keys its dark palette off as well, so one `class="cratis-dark"` on the body serves both. |
+| `cssLayer` | `{ name: primeReactCssLayer, order: primeReactCssLayerOrder }` | The cascade layer the theme is emitted into — `primereact`, declared between Tailwind's `base` and `components` layers (`theme, base, primereact, components, utilities`), so the preflight reset does not strip what the theme gives a cell or an input while a utility class on a PrimeReact element still wins. A string names the layer and keeps that order; `false` emits the theme unlayered. |
+
+```tsx
+import Aura from '@primeuix/themes/aura';
+import { styledMode } from '@cratis/components/styled';
+
+<CratisComponentsProvider value={{ license, ...styledMode({ preset: Aura, darkModeSelector: 'system' }) }}>
+```
+
+Extend `CratisPreset` the way you would any preset:
+
+```ts
+import { definePreset } from '@primeuix/themes';
+import { CratisPreset } from '@cratis/components/styled';
+
+export const BrandPreset = definePreset(CratisPreset, {
+    semantic: {
+        primary: {
+            50: '{sky.50}',   100: '{sky.100}', 200: '{sky.200}',
+            300: '{sky.300}', 400: '{sky.400}', 500: '{sky.500}',
+            600: '{sky.600}', 700: '{sky.700}', 800: '{sky.800}',
+            900: '{sky.900}', 950: '{sky.950}',
+        },
+    },
+});
+```
+
+```tsx
+<CratisComponentsProvider value={{ license, ...styledMode({ preset: BrandPreset }) }}>
+```
 
 ## Override one component with CSS
 
-When you want to tweak a single widget without redesigning anything, plain CSS works on top of the preset. Applying a preset is what makes PrimeReact emit its own `.p-*` class names, so a global rule reaches them:
+When you want to tweak a single widget without redesigning anything, plain CSS works on top of the theme. In styled mode PrimeReact's elements carry their `p-*` class names, so a global rule reaches them — and because the theme is emitted into the `primereact` cascade layer, a plain unlayered rule in your own stylesheet wins regardless of specificity or order, exactly as it did against PrimeReact 10's stylesheet themes (which were wrapped in `@layer primereact` too):
 
 ```css
 /* yourApp.css */
@@ -35,7 +84,9 @@ When you want to tweak a single widget without redesigning anything, plain CSS w
 ```
 
 > [!WARNING]
-> Those class names exist **only while a preset is applied**. Run unstyled — or under the [Cratis baseline theme](baseline-theme.md) — and PrimeReact emits no `p-*` class at all; parts are identified by data attributes instead (`[data-scope="button"]`, `[data-scope="select"][data-part="trigger"]`). A selector written against a v10 class name silently matches nothing.
+> Those class names exist **only in styled mode** — they come from `primeReactStyles`, not from the preset. Run unstyled, or under the [Cratis baseline theme](baseline-theme.md), and PrimeReact emits no `p-*` class at all; parts are identified by data attributes instead (`[data-scope="button"]`, `[data-scope="select"][data-part="trigger"]`). A selector written against a v10 class name silently matches nothing there.
+
+Pass `cssLayer: false` to emit the theme unlayered instead; its rules then compete with yours on specificity and order alone, and being injected at runtime they arrive last.
 
 …or target your own class names on Cratis wrappers:
 
@@ -67,7 +118,7 @@ For multi-slot composites like `StepperCommandDialog` or `DataPage`, the `classN
 
 ## Tint a specific Cratis surface
 
-Validation error text, the FormElement addon, breadcrumb bottom borders, and other Cratis-specific surfaces read from `--cratis-*` tokens (not from PrimeReact's design tokens). Override the relevant token to retint just those surfaces while leaving the preset untouched:
+Validation error text, the FormElement addon, breadcrumb bottom borders, and other Cratis-specific surfaces read from `--cratis-*` tokens (not from PrimeReact's design tokens). Override the relevant token to retint just those surfaces while leaving the theme untouched:
 
 ```css
 :root {
@@ -99,10 +150,14 @@ When CSS overrides aren't enough — for example, when you need to attach a clas
 
 `pt`, `ptOptions`, and `unstyled` are typed from the underlying PrimeReact component, so your IDE autocompletes the available slot names.
 
+## Coming from a PrimeReact 10 theme stylesheet
+
+If your CSS was written against the variables a v10 theme published on `:root` — `--surface-ground`, `--surface-card`, `--surface-border`, `--text-color`, `--primary-color`, the `--surface-0…900` and `--blue-*` / `--gray-*` scales — those names resolve to nothing on PrimeReact 11. `@cratis/components/primereact-v10-palette` restores every one of them with the `lara-light-blue` / `lara-dark-blue` values, following the active preset where v11 has an equivalent. Import it after `tokens` and `styles`; nothing new should be written against those names. See [the migration guide](../migration.md#theming-without-a-theme-stylesheet).
+
 ## When to choose another setup
 
 This setup stops being a good fit when:
 
-- You don't want the extra `@primeuix/themes` dependency — use the [Cratis baseline theme](baseline-theme.md) instead.
-- The preset is "almost" but not your brand — use [a custom palette on top of a theme](custom-palette.md) and customize the preset's design tokens.
+- You don't want the extra `@primereact/styles` and `@primeuix/themes` dependencies — use the [Cratis baseline theme](baseline-theme.md) instead.
+- The preset is "almost" but not your brand — use [a custom palette on top of a theme](custom-palette.md) and derive your own preset from `CratisPreset` with `definePreset`.
 - You're integrating into a design system that defines its own button, dialog, and input visuals — use [fully unstyled mode](unstyled.md) and bring every visual yourself.

--- a/Documentation/Styling/toc.yml
+++ b/Documentation/Styling/toc.yml
@@ -4,7 +4,7 @@
   href: getting-started.md
 - name: Use the Cratis baseline theme
   href: baseline-theme.md
-- name: Use a PrimeReact theme (preset, needs a license)
+- name: Use PrimeReact's styled mode (preset, needs a license)
   href: themed.md
 - name: Use a custom palette on top of a PrimeReact theme
   href: custom-palette.md

--- a/Documentation/coming-from-primereact.md
+++ b/Documentation/coming-from-primereact.md
@@ -114,7 +114,7 @@ Selection, the resizable split, and disabling menu items until a row is selected
 | `DataTable value={...}` + `useEffect` fetch | `DataTableForObservableQuery query={...}` (live) or `DataTableForQuery` |
 | Split panes + selection + detail wiring | `DataPage` with `detailsComponent` |
 | A multi-step wizard you build yourself | `StepperCommandDialog` |
-| A PrimeReact theme | the Cratis baseline theme or a `@primeuix/themes` preset, plus `--cratis-*` tokens for repainting |
+| A PrimeReact theme | the Cratis baseline theme, or PrimeReact's styled mode (`styledMode()` — a `@primeuix/themes` preset plus PrimeReact's component styles), plus `--cratis-*` tokens for repainting |
 
 ## The v11 module renames
 
@@ -179,9 +179,9 @@ Three things bite even when you only use Cratis wrappers.
 
 **PrimeReact is now a peer dependency.** You install `primereact`, `@primereact/core`, `@primereact/headless` and `primeicons` yourself. Two copies of PrimeReact means two `PrimeReactProvider` contexts, which breaks overlays and `pt` with no error to point at — the peer declaration is what prevents that. See [Getting started](/components/getting-started/).
 
-**PrimeReact 11 ships zero CSS.** `primereact/resources/themes/*.css` does not exist. A theme is now a `@primeuix/themes` preset — a JavaScript token object turned into `--p-*` custom properties at runtime by the provider — or the [Cratis baseline theme](Styling/baseline-theme.md), or your own `pt`. **PrimeReact 11 needs a PrimeUI license key whichever you pick** — the check runs when the provider mounts, not when a theme is applied. See [Licensing](migration.md#licensing) and [Styling](/components/styling/).
+**PrimeReact 11 ships zero CSS.** `primereact/resources/themes/*.css` does not exist. A theme is now [PrimeReact's styled mode](Styling/themed.md) — `styledMode()` from `@cratis/components/styled`, which hands the provider a `@primeuix/themes` preset (a JavaScript token object turned into `--p-*` custom properties at runtime) together with PrimeReact's own component styles; a preset by itself paints nothing — or the [Cratis baseline theme](Styling/baseline-theme.md), or your own `pt`. **PrimeReact 11 needs a PrimeUI license key whichever you pick** — the check runs when the provider mounts, not when a theme is applied. See [Licensing](migration.md#licensing) and [Styling](/components/styling/).
 
-**Unstyled elements carry no `p-*` class.** With no preset applied, PrimeReact identifies parts by data attributes instead — `[data-scope="dialog"][data-part="close"]`, `[data-scope="select"][data-part="trigger"]`. CSS selectors written against v10 class names silently match nothing. (`pt` slot keys are unaffected, though the top-level keys follow the renames above: `select`, not `dropdown`.)
+**Outside styled mode, elements carry no `p-*` class.** The `primereact` primitives identify parts by data attributes — `[data-scope="dialog"][data-part="close"]`, `[data-scope="select"][data-part="trigger"]`; the `p-*` class names come from PrimeReact's component styles, which only `styledMode()` applies. Elsewhere, CSS selectors written against v10 class names silently match nothing. (`pt` slot keys are unaffected, though the top-level keys follow the renames above: `select`, not `dropdown`.)
 
 Two smaller ones: `Button` renders its content as **children**, not `label`/`icon` props; and the data-table selection event is now `DataTableSelectionChangeEvent<T>` rather than `DataTableSelectionSingleChangeEvent`.
 

--- a/Documentation/getting-started.mdx
+++ b/Documentation/getting-started.mdx
@@ -41,7 +41,7 @@ You can build that straight on PrimeReact — instantiate the command, track its
 :::caution[PrimeReact 11 is not MIT]
 `@cratis/components` is MIT, but as of 3.0.0 it builds on **PrimeReact 11**, which is part of
 PrimeTek's commercial **PrimeUI** family — as are `primeicons` 8.x, `@primereact/core`,
-`@primereact/headless`, `@primeuix/themes` and `@primeuix/styled`. PrimeReact 10 was MIT; 11 is not.
+`@primereact/headless`, `@primereact/styles`, `@primeuix/themes` and `@primeuix/styled`. PrimeReact 10 was MIT; 11 is not.
 
 A **PrimeUI license key is required regardless of how you style** — the check runs when
 `PrimeReactProvider` mounts, not when a theme is applied. Without one you get a console warning and
@@ -115,7 +115,7 @@ No `isExecuting` flag, no button wiring, no duplicate validation logic — and b
 The components render structurally the moment the provider is mounted; their *look* is a separate, deliberate choice. PrimeReact 11 is unstyled-first, so pick one setup on the [Styling](/components/styling/) page:
 
 - the **Cratis baseline theme** (`import '@cratis/components/theme'` + `class="cratis-theme"`),
-- a styled `@primeuix/themes` **preset** via `value={{ theme: { preset } }}`, or
+- PrimeReact's **styled mode** — `import { styledMode } from '@cratis/components/styled'` and `value={{ license, ...styledMode() }}`, which hands the provider a `@primeuix/themes` preset *and* PrimeReact's own component styles (a preset alone emits tokens but paints nothing; needs `@primereact/styles` and `@primeuix/themes` installed), or
 - fully unstyled, with your own `pt` / CSS.
 
 ## Recap

--- a/Documentation/migration.md
+++ b/Documentation/migration.md
@@ -37,7 +37,7 @@ Notes:
 - `primereact` pins `@primereact/core` and `@primereact/headless` to its own **exact** version, so installing `primereact@11.1.0` gives you 11.1.0 of all three. Declaring them anyway is what makes a strict installer (pnpm, Yarn PnP) resolve them for the library too.
 - `primeicons` went **7 → 8** alongside PrimeReact 11.
 - `@primereact/types` is an **optional** peer. You only need it declared if your own code imports our prop types (they re-export `@primereact/types/*` shapes). It arrives transitively via `@primereact/core` in a hoisting installer.
-- `@primeuix/themes` is **not** a peer. Install it only if you want a styled preset — see [Theming without a theme stylesheet](#theming-without-a-theme-stylesheet).
+- `@primereact/styles` and `@primeuix/themes` are **optional** peers. Install them only for PrimeReact's styled mode — see [Theming without a theme stylesheet](#theming-without-a-theme-stylesheet). The baseline theme and unstyled mode need neither.
 - If your app carried a `resolutions` / `overrides` entry to collapse PrimeReact into one copy, **you can delete it** — the peer declaration is what enforces that now.
 
 ### Arc peer range is unchanged
@@ -112,38 +112,57 @@ Per-column filter menus (`<Column filter dataType="…" />`), a global search bo
 
 ## Theming without a theme stylesheet
 
-**PrimeReact 11 ships zero CSS.** `primereact/resources/themes/*.css` does not exist. Presets are plain **JavaScript token objects** (`@primeuix/themes` — Aura, Lara, Nora) that `@primeuix/styled` turns into `--p-*` custom properties **at runtime** when you hand one to the provider.
+**PrimeReact 11 ships zero CSS.** `primereact/resources/themes/*.css` does not exist, and the `primereact` package is **unstyled primitives**: they render structural markup with `data-scope` / `data-part` attributes and **no `p-*` class names**. A theme is now two things handed to the provider at runtime: a **preset** — a plain JavaScript token object (`@primeuix/themes` — Aura, Lara, Nora) that `@primeuix/styled` turns into `--p-*` custom properties — and PrimeReact's **component styles** (`@primereact/styles`), which put the `p-*` class names on the primitives and carry the CSS the tokens drive. PrimeReact's own styled components (`@primereact/ui`) are just the primitives with those styles preset; `@cratis/components` builds on the primitives, so a preset alone (`theme: { preset }`) emits tokens but paints nothing.
 
-The chain is: **preset (JS) → `--p-*` (runtime) → `--cratis-*` (our token layer) → component CSS.** Our `--cratis-*` tokens resolve the v11 token first and fall back to the v10 variable, so an app that still has a compiled v10 theme on the page during its port keeps working, and nothing breaks the day it is removed.
+The chain is: **preset (JS) → `--p-*` (runtime) → `--cratis-*` (our token layer) → component CSS**, and in styled mode also **`primeReactStyles` → `p-*` class names + PrimeReact's component CSS**. Our `--cratis-*` tokens resolve the v11 token first and fall back to the v10 variable, so an app that still has a compiled v10 theme on the page during its port keeps working, and nothing breaks the day it is removed.
 
 Pick one of three paths — the [Styling](Styling/index.md) section walks each one:
 
-**A. Unstyled-first (default).** Ship structure plus the `--cratis-*` token layer and bring your own visuals via `pt` / CSS / Tailwind. Your existing `--surface-*` and `--cratis-*` overrides keep working.
-
-```tsx
-<CratisComponentsProvider value={{ unstyled: true, pt: myPreset }}>
-```
-
-**B. [The Cratis baseline theme](Styling/baseline-theme.md).** Cratis-authored MIT CSS that assigns the `--cratis-*` tokens directly, light and dark, for a polished default with no preset and no `@primeuix/themes` dependency. It defers to a preset's `--p-*` values when one is present.
+**A. [The Cratis baseline theme](Styling/baseline-theme.md).** Cratis-authored MIT CSS that assigns the `--cratis-*` tokens directly, light and dark, for a polished default with no preset and no extra dependency. It defers to a preset's `--p-*` values when one is present.
 
 ```diff
 - import 'primereact/resources/themes/lara-dark-blue/theme.css';
 + import '@cratis/components/theme';
 ```
 
-**C. [A styled `@primeuix/themes` preset](Styling/themed.md).**
+**B. [PrimeReact's styled mode](Styling/themed.md).** `styledMode()` from `@cratis/components/styled` returns `{ theme, defaults }` — a `@primeuix/themes` preset (default `CratisPreset`: Lara with the blue primary and gray surfaces of `lara-light-blue` / `lara-dark-blue`) plus `primeReactStyles`, PrimeReact's own component styles, which the provider applies to every primitive rendered under it — this library's and your own. Needs `@primereact/styles` and `@primeuix/themes` installed. Options: `preset` (any preset or `definePreset` result), `darkModeSelector` (default `.cratis-dark`), `cssLayer` (default the `primereact` layer, ordered between Tailwind's `base` and `components`, so a plain `.p-button { … }` in your CSS overrides the theme just as it did against v10's `@layer primereact` stylesheets; `false` emits unlayered).
 
 ```diff
 - import 'primereact/resources/themes/lara-dark-blue/theme.css';
-+ import Aura from '@primeuix/themes/aura';
++ import { styledMode } from '@cratis/components/styled';
   // …
 - <CratisComponentsProvider>
-+ <CratisComponentsProvider value={{ theme: { preset: Aura }, license: '…' }}>
++ <CratisComponentsProvider value={{ license: '…', ...styledMode() }}>
 ```
 
-`npm i @primeuix/themes` for this path only.
+`npm i @primereact/styles @primeuix/themes` for this path only.
 
-`CratisComponentsProvider` takes everything through its single `value` prop, which is deep-merged onto PrimeReact's provider config — `unstyled`, `pt`, `ptOptions`, `ripple`, `inputVariant`, `zIndex`, `locale`, `theme` and `license`. It also accepts a `toaster` prop (`true` or a `ToasterProps` object) to mount a `<Toaster />` for you.
+**C. Fully unstyled.** Ship structure plus the `--cratis-*` token layer and bring your own visuals via `pt` / CSS / Tailwind. Your existing `--cratis-*` overrides keep working.
+
+```tsx
+<CratisComponentsProvider value={{ unstyled: true, pt: myPreset }}>
+```
+
+### If your CSS was written against a v10 theme's variables
+
+A v10 theme stylesheet published `--surface-ground`, `--surface-card`, `--surface-border`, `--surface-hover`, `--text-color`, `--text-color-secondary`, `--primary-color`, `--highlight-bg`, `--focus-ring`, `--maskbg`, `--border-radius`, the `--surface-0…900` and `--primary-50…900` scales, the `--gray` / `--blue` / `--green` / `--yellow` / `--cyan` / `--pink` / `--indigo` / `--teal` / `--orange` / `--bluegray` / `--purple` / `--red-50…900` scales, the `--surface-a…f` aliases, `--content-padding` and `--inline-spacing` on `:root`. On PrimeReact 11 they resolve to nothing the day it is installed — borders vanish, cards lose their background. **`@cratis/components/primereact-v10-palette`** restores every one of them with the `lara-light-blue` / `lara-dark-blue` values, so those call sites keep working:
+
+```diff
+- import 'primereact/resources/themes/lara-dark-blue/theme.css';
+  import '@cratis/components/tokens';
+  import '@cratis/components/styles';
++ import '@cratis/components/primereact-v10-palette';
+  // …
++ <CratisComponentsProvider value={{ license: '…', ...styledMode() }}>
+```
+
+- The **semantic** names (`--surface-card`, `--text-color`, `--primary-color`, …) resolve from the active preset's `--p-*` tokens where v11 has an equivalent, with the Lara values as the fallback — so they follow whatever preset styled mode applies.
+- The **numbered scales** are the lara-blue values verbatim. The v10 dark surface scale was inverted, so `--p-surface-*` cannot stand in for it.
+- Light and dark switch through `light-dark()`, keyed off `.cratis-dark` (the file sets `color-scheme: dark` on it) — the same class the baseline theme and `styledMode()` use.
+
+Import order: `tokens`, `styles`, then the palette (and/or `theme`). It exists so what is already written keeps working — write nothing new against those names; use `--cratis-*` (or `--p-*`) instead.
+
+`CratisComponentsProvider` takes everything through its single `value` prop, which is deep-merged onto PrimeReact's provider config — `unstyled`, `pt`, `ptOptions`, `ripple`, `inputVariant`, `zIndex`, `locale`, `theme`, `defaults` and `license`. It also accepts a `toaster` prop (`true` or a `ToasterProps` object) to mount a `<Toaster />` for you.
 
 ## Dialog
 
@@ -177,13 +196,13 @@ A few v10 features have no v11 equivalent. The props are **kept so your code sti
 Some wrappers also **narrowed their surface** (they no longer leak PrimeReact's full API):
 
 - **`Column`** keeps the `field` / `header` / `body` / `sortable` / `filter` authoring model; v10 extras like `editor`, `frozen`, `footer`, `colSpan` and `expander` are not carried over.
-- **`Dropdown`** exposes a curated single/multi select surface (`value`, `options`, `optionLabel` / `optionValue`, `placeholder`, `filter`, `multiple`, `showClear`, `style`, `id`, `name`, `aria-*`, …) plus `pt` / `ptOptions` / `unstyled` — it no longer accepts arbitrary PrimeReact Select props.
+- **`Dropdown`** exposes a curated single/multi select surface (`value`, `options`, `optionLabel` / `optionValue`, `placeholder`, `filter`, `multiple`, `showClear`, `style`, `id`, `name`, `aria-*`, …) plus `pt` / `ptOptions` / `unstyled` — it no longer accepts arbitrary PrimeReact Select props. `optionLabel` / `optionValue` default to `label` / `value` when the option objects carry those fields — the v10 `Dropdown` convention — so `[{ label, value }]` options with a scalar `value` keep matching (v11's `Select` compares the option object itself otherwise).
 - The **`DataPage` action toolbar** replaces the v10 Menubar: `menubarPt` / `menubarPtOptions` / `menubarUnstyled` now target the toolbar's **buttons**, and the paginator is styled via `paginatorClassName` (+ `paginatorAriaLabels`), not `pt`.
 - **`StepperCustomizationProps`** is now Cratis-owned (it no longer aliases PrimeReact's `StepperProps`). Same shape, minus the removed slots.
 
 ### If you write `pt` definitions or CSS selectors against PrimeReact internals
 
-v11 is unstyled-first: with no preset applied, PrimeReact elements carry **no `p-*` class at all**. Parts are identified by data attributes instead — `[data-scope="dialog"][data-part="close"]`, `[data-scope="select"][data-part="trigger"]`, and so on. Selectors written against v10 class names will silently match nothing. (`pt` slot keys are unaffected.)
+v11 is unstyled-first: outside [styled mode](Styling/themed.md), PrimeReact elements carry **no `p-*` class at all**. Parts are identified by data attributes instead — `[data-scope="dialog"][data-part="close"]`, `[data-scope="select"][data-part="trigger"]`, and so on. Selectors written against v10 class names will silently match nothing there. In styled mode the `p-*` class names are back — `styledMode()` applies PrimeReact's component styles to every primitive — and the theme sits in the `primereact` cascade layer, so a plain `.p-button { … }` in your own CSS overrides it as it did on v10. (`pt` slot keys are unaffected either way.)
 
 ## What's new (nothing to migrate — just available)
 
@@ -191,11 +210,14 @@ v11 is unstyled-first: with no preset applied, PrimeReact elements carry **no `p
 - **[Display](Display/index.md)** — `Tag`, `Badge`, `Chip`, `Skeleton`, `Avatar`, `ProgressBar`.
 - **CommandForm fields** — [PasswordField](CommandForm/password-field.md), [ToggleSwitchField](CommandForm/toggle-switch-field.md), [RatingField](CommandForm/rating-field.md).
 - **[AutoCommandForm](CommandForm/auto-command-form.md)** — generates a `CommandForm`'s fields from the command's own `propertyDescriptors`, with a `registerFieldTypeProvider` registry for custom types.
-- **[`@cratis/components/theme`](Styling/baseline-theme.md)** — the Cratis baseline theme (MIT CSS).
+- **[`@cratis/components/theme`](Styling/baseline-theme.md)** — the Cratis baseline theme (MIT CSS). It now positions the dialog backdrop and positioner itself; previously a baseline-theme dialog could render below the page content.
+- **[`@cratis/components/styled`](Styling/themed.md)** — `styledMode()`, `CratisPreset`, `primeReactStyles`, `primeReactCssLayer`, `primeReactCssLayerOrder` and `cratisDarkModeSelector`: PrimeReact's styled mode, wired for the provider.
+- **`@cratis/components/primereact-v10-palette`** — the PrimeReact 10 theme variables (`--surface-*`, `--text-color`, `--primary-color`, the color scales, …) restored with the lara-blue values, for CSS already written against them.
+- **`Dropdown`** reads `label` / `value` off option objects when `optionLabel` / `optionValue` are omitted — the v10 `Dropdown` convention.
 
 ## Licensing
 
-**PrimeReact 11 is no longer MIT.** PrimeReact 10 was; 11 is part of PrimeTek's commercial **PrimeUI** family, along with `primeicons` 8.x, `@primereact/core`, `@primereact/headless`, `@primeuix/themes` and `@primeuix/styled`.
+**PrimeReact 11 is no longer MIT.** PrimeReact 10 was; 11 is part of PrimeTek's commercial **PrimeUI** family, along with `primeicons` 8.x, `@primereact/core`, `@primereact/headless`, `@primereact/styles`, `@primeuix/themes` and `@primeuix/styled`.
 
 `@cratis/components` itself stays **MIT**. What changed is what it depends on — and because PrimeReact is a peer dependency as of 3.0.0, you install it and its terms apply to you directly.
 
@@ -207,7 +229,7 @@ An earlier version of this page said unstyled rendering and the Cratis baseline 
 <CratisComponentsProvider value={{ license: '…' }}>
 ```
 
-What the styling choice changes is whether you additionally depend on `@primeuix/themes`. [The Cratis baseline theme](Styling/baseline-theme.md) is Cratis-authored MIT CSS embedding no PrimeTek values, so that *stylesheet* carries no PrimeTek terms — but rendering it still runs PrimeReact 11, which needs a key.
+What the styling choice changes is whether you additionally depend on `@primereact/styles` and `@primeuix/themes` — both PrimeUI-licensed too, and needed only for styled mode. [The Cratis baseline theme](Styling/baseline-theme.md) is Cratis-authored MIT CSS embedding no PrimeTek values, so that *stylesheet* carries no PrimeTek terms — but rendering it still runs PrimeReact 11, which needs a key.
 
 ### Which license you need
 

--- a/Source/.storybook/preview.js
+++ b/Source/.storybook/preview.js
@@ -7,23 +7,24 @@ import 'primeicons/primeicons.css';
 import '../styles.css';
 import './preview.css';
 import '../theme.css';
+import '../primereact-v10-palette.css';
 import Aura from '@primeuix/themes/aura';
 import { CratisComponentsProvider } from '../Common/CratisComponentsProvider';
+import { styledMode } from '../Styled';
 import { tailwindPtPreset } from './pt-preset';
 
-// PrimeReact 11 is unstyled-first and token-based: the styled look comes from a
-// @primeuix/themes preset applied through the provider's `theme` config (which
-// injects the `--p-*` design tokens), and dark mode is toggled with a class the
-// preset's `darkModeSelector` targets. There are no theme CSS files to <link>
-// anymore (the v10 `primereact/resources/themes/lara-*` files were removed).
+// PrimeReact 11 is unstyled-first and token-based: the styled look is styled mode -
+// PrimeReact's own component styles handed to every primitive through the provider's
+// `defaults`, painted by a @primeuix/themes preset applied through its `theme` config
+// (which injects the `--p-*` design tokens). A preset alone styles nothing; that is what
+// `styledMode()` composes. Dark mode is toggled with the class the preset's
+// `darkModeSelector` targets. There are no theme CSS files to <link> anymore (the v10
+// `primereact/resources/themes/lara-*` files were removed).
 const DARK_SELECTOR = 'cratis-dark';
 
-const styledTheme = { preset: Aura, options: { darkModeSelector: `.${DARK_SELECTOR}` } };
-
-// PrimeReact 11's styled layer (@primeuix/themes) is license-gated: without a valid
-// PrimeUI license key the components fall back to unstyled and a nag banner appears.
-// Set STORYBOOK_PRIMEUI_LICENSE to preview the styled (Aura) modes with your own key;
-// the license-free default below is the unstyled + Tailwind `pt` path.
+// PrimeReact 11 verifies a PrimeUI license key when its provider mounts, whatever the
+// styling path; without one a nag banner appears. Set STORYBOOK_PRIMEUI_LICENSE to your
+// own key. The default mode below is the unstyled + Tailwind `pt` path.
 const PRIMEUI_LICENSE = import.meta.env?.STORYBOOK_PRIMEUI_LICENSE;
 const withLicense = (value) => (PRIMEUI_LICENSE ? { ...value, license: PRIMEUI_LICENSE } : value);
 
@@ -41,16 +42,22 @@ const STYLING_MODES = {
         providerValue: { unstyled: true },
     },
     'styled-dark': {
-        title: 'Path A — Styled (Aura Dark) — needs PrimeUI license',
+        title: 'Path A — Styled mode, Cratis preset, dark',
         dark: true,
         bodyClass: null,
-        providerValue: withLicense({ ripple: true, theme: styledTheme }),
+        providerValue: withLicense({ ripple: true, ...styledMode() }),
     },
     'styled-light': {
-        title: 'Path A — Styled (Aura Light) — needs PrimeUI license',
+        title: 'Path A — Styled mode, Cratis preset, light',
         dark: false,
         bodyClass: null,
-        providerValue: withLicense({ ripple: true, theme: styledTheme }),
+        providerValue: withLicense({ ripple: true, ...styledMode() }),
+    },
+    'styled-aura-dark': {
+        title: 'Path A — Styled mode, Aura preset, dark',
+        dark: true,
+        bodyClass: null,
+        providerValue: withLicense({ ripple: true, ...styledMode({ preset: Aura }) }),
     },
     'cratis-theme': {
         title: 'Path B — Cratis baseline theme, dark (no license)',

--- a/Source/Common/CratisComponentsProvider.tsx
+++ b/Source/Common/CratisComponentsProvider.tsx
@@ -62,8 +62,11 @@ export const mergeCratisComponentsConfig = (value: CratisComponentsConfig | unde
  * - **Unstyled (default posture):** pass nothing, or `value={{ unstyled: true }}`, and
  *   style the structural markup yourself through the `--cratis-*` token layer, your own
  *   CSS, Tailwind, or `pt` definitions.
- * - **Styled:** pass `value={{ theme: { preset } }}` with a `@primeuix/themes` preset
- *   (e.g. `import Aura from '@primeuix/themes/aura'`) to opt into a token-based styled look.
+ * - **Styled:** spread `styledMode()` from `@cratis/components/styled` into `value` -
+ *   PrimeReact's own component styles for every primitive plus a `@primeuix/themes`
+ *   preset (the Cratis preset by default, `styledMode({ preset: Aura })` for another).
+ *   A preset on `theme` alone only emits design tokens; the primitives render without
+ *   `p-*` classes until `defaults` gives them their styles, which is what `styledMode()` does.
  * - Pass `value={{ pt, ptOptions }}` to apply global per-component pass-through.
  *
  * **PrimeUI license.** PrimeReact 11 is no longer MIT — its provider verifies a PrimeUI

--- a/Source/DataTables/DataTableCore.tsx
+++ b/Source/DataTables/DataTableCore.tsx
@@ -200,12 +200,13 @@ export const DataTableCore = <TData extends object>({
                                             // aria-sort belongs on the column header, not the sort button; PrimeReact 11's
                                             // Sort part puts it on its role="button" element (invalid ARIA), so strip it here.
                                             <PrimeDataTable.Sort field={column.props.field} pt={{ root: { 'aria-sort': undefined } }}>
-                                                {column.props.header}
+                                                <PrimeDataTable.THeadTitle>{column.props.header}</PrimeDataTable.THeadTitle>
                                                 <PrimeDataTable.SortIndicator match="asc"> ▲</PrimeDataTable.SortIndicator>
                                                 <PrimeDataTable.SortIndicator match="desc"> ▼</PrimeDataTable.SortIndicator>
                                             </PrimeDataTable.Sort>
                                         ) : (
-                                            <span>{column.props.header}</span>
+                                            // The title part, not a bare span, so a theme's column-title weight reaches it.
+                                            <PrimeDataTable.THeadTitle>{column.props.header}</PrimeDataTable.THeadTitle>
                                         )}
                                         {column.props.filter && (column.props.filterField ?? column.props.field) && (
                                             <ColumnFilterMenu
@@ -243,7 +244,10 @@ export const DataTableCore = <TData extends object>({
                             </PrimeDataTable.Row>
                         )}
                     </PrimeDataTable.TBody>
-                    <PrimeDataTable.EmptyTBody>
+                    {/* v11 classes the empty body `p-datatable-empty-message` alone, so a theme's
+                        `.p-datatable-tbody > tr > td` cell rules never reach the message row; the
+                        body class puts the empty row on the same footing as a data row. */}
+                    <PrimeDataTable.EmptyTBody className="p-datatable-tbody">
                         <PrimeDataTable.Row>
                             <PrimeDataTable.Cell colSpan={Math.max(columns.length, 1)}>{emptyMessage}</PrimeDataTable.Cell>
                         </PrimeDataTable.Row>

--- a/Source/Display/Message.tsx
+++ b/Source/Display/Message.tsx
@@ -17,7 +17,25 @@ export interface MessageProps {
     children?: React.ReactNode;
     /** Extra class name applied to the message root. */
     className?: string;
+    /**
+     * The icon shown ahead of the text. Defaults to the glyph PrimeReact 10 showed for the
+     * severity; pass `false` for no icon, or a node of your own.
+     */
+    icon?: React.ReactNode | false;
 }
+
+/**
+ * The severity glyphs of PrimeReact 10's `Message`, which composed its own icon; v11's
+ * `Message.Icon` part renders whatever it is given and nothing on its own.
+ */
+const severityIcons: Record<MessageSeverity, string> = {
+    info: 'pi pi-info-circle',
+    success: 'pi pi-check',
+    warn: 'pi pi-exclamation-triangle',
+    error: 'pi pi-times-circle',
+    secondary: 'pi pi-info-circle',
+    contrast: 'pi pi-info-circle',
+};
 
 /**
  * A declarative inline message built on PrimeReact 11's compositional `Message` parts.
@@ -26,9 +44,12 @@ export interface MessageProps {
  * `Message.Text` in 11; this preserves the flat call shape so an inline notice stays a
  * single element at the call site.
  */
-export const Message = ({ severity = 'info', text, children, className }: MessageProps) => (
+export const Message = ({ severity = 'info', text, children, className, icon }: MessageProps) => (
     <PrimeMessage.Root severity={severity} className={className}>
         <PrimeMessage.Content>
+            {icon !== false && (
+                <PrimeMessage.Icon>{icon ?? <i className={severityIcons[severity]} />}</PrimeMessage.Icon>
+            )}
             <PrimeMessage.Text>{children ?? text}</PrimeMessage.Text>
         </PrimeMessage.Content>
     </PrimeMessage.Root>

--- a/Source/Dropdown/Dropdown.tsx
+++ b/Source/Dropdown/Dropdown.tsx
@@ -30,10 +30,16 @@ export interface DropdownProps<T = unknown> {
     /** Source array of option objects (or primitives). */
     options?: unknown[];
 
-    /** Property name on each option object used as the visible label. */
+    /**
+     * Property name on each option object used as the visible label. When omitted and the
+     * options are objects carrying a `label`, that is used - the v10 `Dropdown` convention.
+     */
     optionLabel?: string;
 
-    /** Property name on each option object used as the underlying value. */
+    /**
+     * Property name on each option object used as the underlying value. When omitted and the
+     * options are objects carrying a `value`, that is used - the v10 `Dropdown` convention.
+     */
     optionValue?: string;
 
     /** Placeholder shown in the trigger when nothing is selected. */
@@ -105,11 +111,22 @@ export interface DropdownProps<T = unknown> {
  * modal dialogs via PrimeReact 11's overlay manager — the v10 `appendTo` /
  * manual z-index workaround is no longer required.
  */
+/**
+ * PrimeReact 10's `Dropdown` read `label` and `value` off option objects when no
+ * `optionLabel` / `optionValue` was given; v11's `Select` compares the option object
+ * itself against the value instead, so `[{ label, value }]` options with a scalar
+ * `value` never match. Resolve the v10 convention here so those call sites keep working.
+ */
+const conventionalField = (options: unknown[] | undefined, field: 'label' | 'value'): string | undefined => {
+    const first = options?.[0];
+    return first !== null && typeof first === 'object' && field in (first as object) ? field : undefined;
+};
+
 export const Dropdown = <T = unknown,>({
     value,
     options,
-    optionLabel,
-    optionValue,
+    optionLabel = conventionalField(options, 'label'),
+    optionValue = conventionalField(options, 'value'),
     placeholder,
     filter,
     multiple,
@@ -154,8 +171,10 @@ export const Dropdown = <T = unknown,>({
                 unstyled={unstyled}>
                 <Select.Trigger>
                     <Select.Value placeholder={placeholder} />
-                    {showClear && <Select.Clear />}
-                    <Select.Arrow />
+                    {/* v11's parts render no glyph of their own - the icon is the composer's to supply.
+                        `Indicator` is the trigger's chevron; `Arrow` would be the popup's pointer. */}
+                    {showClear && <Select.Clear><i className="pi pi-times" /></Select.Clear>}
+                    <Select.Indicator><i className="pi pi-chevron-down" /></Select.Indicator>
                 </Select.Trigger>
                 <Select.Portal>
                     <Select.Positioner>

--- a/Source/Dropdown/for_Dropdown/when_options_carry_label_and_value.ts
+++ b/Source/Dropdown/for_Dropdown/when_options_carry_label_and_value.ts
@@ -1,0 +1,52 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// @vitest-environment jsdom
+
+import React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { Dropdown } from '../Dropdown';
+import { CratisComponentsProvider } from '../../Common/CratisComponentsProvider';
+
+/**
+ * PrimeReact 10's `Dropdown` displayed `option.label` and compared `option.value` when no
+ * `optionLabel` / `optionValue` was given, so `[{ label, value }]` with a scalar `value` was
+ * the everyday shape. v11's `Select` matches the option object itself against the value, which
+ * shows the raw scalar in the trigger. The wrapper keeps the v10 convention.
+ */
+describe('when options carry label and value', () => {
+    let root: Root;
+    let container: HTMLDivElement;
+    let triggerText: string;
+
+    beforeEach(async () => {
+        (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+        (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver ??= class {
+            observe() { } unobserve() { } disconnect() { }
+        };
+
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        root = createRoot(container);
+
+        await act(async () => {
+            root.render(React.createElement(CratisComponentsProvider, {
+                children: React.createElement(Dropdown, {
+                    value: 'new',
+                    options: [{ label: 'New project', value: 'new' }, { label: 'Sample', value: 'sample' }],
+                })
+            }));
+        });
+
+        triggerText = container.querySelector('[data-scope="select"][data-part="value"]')?.textContent ?? '';
+    });
+
+    afterEach(async () => {
+        await act(async () => root.unmount());
+        container.remove();
+    });
+
+    it('should show the label of the selected option', () => {
+        triggerText.should.equal('New project');
+    });
+});

--- a/Source/MIGRATION.md
+++ b/Source/MIGRATION.md
@@ -52,7 +52,8 @@ Notes:
 - `@primereact/types` is an **optional** peer. You only need it declared if your own
   code imports our prop types (they re-export `@primereact/types/*` shapes). It arrives
   transitively via `@primereact/core` in a hoisting installer.
-- `@primeuix/themes` is **not** a peer. Install it only if you want a styled preset (§6).
+- `@primereact/styles` and `@primeuix/themes` are **optional** peers. Install them only for
+  PrimeReact's styled mode (§6). The baseline theme and unstyled mode need neither.
 - If your app carried a `resolutions` / `overrides` entry to collapse PrimeReact into one
   copy, **you can delete it** — the peer declaration is what enforces that now.
 
@@ -192,51 +193,104 @@ paginator range report are all restored — no API change to opt in beyond `filt
 
 ## 6. Theming — there is no theme stylesheet any more
 
-**PrimeReact 11 ships zero CSS.** `primereact/resources/themes/*.css` does not exist.
-Presets are plain **JavaScript token objects** (`@primeuix/themes` — Aura, Lara, Nora)
-that `@primeuix/styled` turns into `--p-*` custom properties **at runtime** when you hand
-one to the provider.
+**PrimeReact 11 ships zero CSS.** `primereact/resources/themes/*.css` does not exist, and
+the `primereact` package is **unstyled primitives**: they render structural markup with
+`data-scope` / `data-part` attributes and **no `p-*` class names**. A theme is now two
+things handed to the provider at runtime: a **preset** — a plain JavaScript token object
+(`@primeuix/themes` — Aura, Lara, Nora) that `@primeuix/styled` turns into `--p-*` custom
+properties — and PrimeReact's **component styles** (`@primereact/styles`), which put the
+`p-*` class names on the primitives and carry the CSS the tokens drive. PrimeReact's own
+styled components (`@primereact/ui`) are just the primitives with those styles preset;
+`@cratis/components` builds on the primitives, so **a preset alone (`theme: { preset }`)
+emits tokens but paints nothing**.
 
 The chain is: **preset (JS) → `--p-*` (runtime) → `--cratis-*` (our token layer) →
-component CSS.** Our `--cratis-*` tokens resolve the v11 token first and fall back to the
-v10 variable, so an app that still has a compiled v10 theme on the page during its port
-keeps working, and nothing breaks the day it is removed.
+component CSS**, and in styled mode also **`primeReactStyles` → `p-*` class names +
+PrimeReact's component CSS**. Our `--cratis-*` tokens resolve the v11 token first and fall
+back to the v10 variable, so an app that still has a compiled v10 theme on the page during
+its port keeps working, and nothing breaks the day it is removed.
 
 Pick one of three paths:
 
-**A. Unstyled-first (default).** Ship structure plus the `--cratis-*` token
-layer and bring your own visuals via `pt` / CSS / Tailwind. Your existing `--surface-*`
-and `--cratis-*` overrides keep working.
-
-```tsx
-<CratisComponentsProvider value={{ unstyled: true, pt: myPreset }}>
-```
-
-**B. The Cratis baseline theme.** Cratis-authored MIT CSS that assigns the
+**A. The Cratis baseline theme.** Cratis-authored MIT CSS that assigns the
 `--cratis-*` tokens directly, light and dark, for a polished default with no preset and
-no key. It defers to a preset's `--p-*` values when one is present.
+no extra dependency. It defers to a preset's `--p-*` values when one is present.
 
 ```diff
 - import 'primereact/resources/themes/lara-dark-blue/theme.css';
 + import '@cratis/components/theme';
 ```
 
-**C. A styled `@primeuix/themes` preset (license-gated — see below).**
+**B. PrimeReact's styled mode.** `styledMode()` from `@cratis/components/styled` returns
+`{ theme, defaults }`: a `@primeuix/themes` preset (default `CratisPreset` — Lara with the
+blue primary and gray surfaces of `lara-light-blue` / `lara-dark-blue`, the dark surface
+scale one step lighter so content sits above the page as it did there, both color schemes) plus
+`primeReactStyles`, PrimeReact's own component styles keyed by primitive name, which the
+provider applies to every primitive rendered under it — this library's and your own. That
+is what makes the `p-*` class names appear and the preset paint them. Options: `preset`
+(any preset or a `definePreset` result — `definePreset(CratisPreset, {...})` to extend),
+`darkModeSelector` (default `.cratis-dark`, the class the baseline theme uses too),
+`cssLayer` (default the `primereact` layer, ordered between Tailwind's `base` and
+`components`, so a plain `.p-button { … }` in your CSS overrides the theme just as it did
+against v10's `@layer primereact` stylesheets and a utility class still wins; `false`
+emits unlayered).
 
 ```diff
 - import 'primereact/resources/themes/lara-dark-blue/theme.css';
-+ import Aura from '@primeuix/themes/aura';
++ import { styledMode } from '@cratis/components/styled';
   // …
 - <CratisComponentsProvider>
-+ <CratisComponentsProvider value={{ theme: { preset: Aura }, license: '…' }}>
++ <CratisComponentsProvider value={{ license: '…', ...styledMode() }}>
 ```
 
-`npm i @primeuix/themes` for this path only.
+`npm i @primereact/styles @primeuix/themes` for this path only (both PrimeUI-licensed —
+see below).
+
+**C. Fully unstyled.** Ship structure plus the `--cratis-*` token layer and bring your
+own visuals via `pt` / CSS / Tailwind. Your existing `--cratis-*` overrides keep working.
+
+```tsx
+<CratisComponentsProvider value={{ unstyled: true, pt: myPreset }}>
+```
+
+### If your CSS was written against a v10 theme's variables
+
+A v10 theme stylesheet published `--surface-ground`, `--surface-card`, `--surface-border`,
+`--surface-hover`, `--text-color`, `--text-color-secondary`, `--primary-color`,
+`--highlight-bg`, `--focus-ring`, `--maskbg`, `--border-radius`, the `--surface-0…900` and
+`--primary-50…900` scales, the `--gray` / `--blue` / `--green` / `--yellow` / `--cyan` /
+`--pink` / `--indigo` / `--teal` / `--orange` / `--bluegray` / `--purple` / `--red-50…900`
+scales, the `--surface-a…f` aliases, `--content-padding` and `--inline-spacing` on `:root`.
+On PrimeReact 11 they resolve to nothing the day it is installed — borders vanish, cards
+lose their background. **`@cratis/components/primereact-v10-palette`** restores every one
+of them with the `lara-light-blue` / `lara-dark-blue` values, so those call sites keep
+working:
+
+```diff
+- import 'primereact/resources/themes/lara-dark-blue/theme.css';
+  import '@cratis/components/tokens';
+  import '@cratis/components/styles';
++ import '@cratis/components/primereact-v10-palette';
+  // …
++ <CratisComponentsProvider value={{ license: '…', ...styledMode() }}>
+```
+
+- The **semantic** names (`--surface-card`, `--text-color`, `--primary-color`, …) resolve
+  from the active preset's `--p-*` tokens where v11 has an equivalent, with the Lara values
+  as the fallback — so they follow whatever preset styled mode applies.
+- The **numbered scales** are the lara-blue values verbatim. The v10 dark surface scale was
+  inverted, so `--p-surface-*` cannot stand in for it.
+- Light and dark switch through `light-dark()`, keyed off `.cratis-dark` (the file sets
+  `color-scheme: dark` on it) — the same class the baseline theme and `styledMode()` use.
+
+Import order: `tokens`, `styles`, then the palette (and/or `theme`). It exists so what is
+already written keeps working — write nothing new against those names; use `--cratis-*`
+(or `--p-*`) instead.
 
 `CratisComponentsProvider` takes everything through its single `value` prop, which is
 deep-merged onto PrimeReact's provider config — `unstyled`, `pt`, `ptOptions`, `ripple`,
-`inputVariant`, `zIndex`, `locale`, `theme` and `license`. It also accepts a `toaster`
-prop (`true` or a `ToasterProps` object) to mount a `<Toaster />` for you.
+`inputVariant`, `zIndex`, `locale`, `theme`, `defaults` and `license`. It also accepts a
+`toaster` prop (`true` or a `ToasterProps` object) to mount a `<Toaster />` for you.
 
 ## 7. Dialog
 
@@ -292,7 +346,10 @@ Some wrappers also **narrowed their surface** (they no longer leak PrimeReact's 
 - **`Dropdown`** exposes a curated single/multi select surface (`value`, `options`,
   `optionLabel` / `optionValue`, `placeholder`, `filter`, `multiple`, `showClear`, `style`,
   `id`, `name`, `aria-*`, …) plus `pt` / `ptOptions` / `unstyled` — it no longer accepts
-  arbitrary PrimeReact Select props.
+  arbitrary PrimeReact Select props. `optionLabel` / `optionValue` default to `label` /
+  `value` when the option objects carry those fields — the v10 `Dropdown` convention — so
+  `[{ label, value }]` options with a scalar `value` keep matching (v11's `Select` compares
+  the option object itself otherwise).
 - The **`DataPage` action toolbar** replaces the v10 Menubar: `menubarPt` /
   `menubarPtOptions` / `menubarUnstyled` now target the toolbar's **buttons**, and the
   paginator is styled via `paginatorClassName` (+ `paginatorAriaLabels`), not `pt`.
@@ -301,11 +358,14 @@ Some wrappers also **narrowed their surface** (they no longer leak PrimeReact's 
 
 ### If you write `pt` definitions or CSS selectors against PrimeReact internals
 
-v11 is unstyled-first: with no preset applied, PrimeReact elements carry **no `p-*` class
-at all**. Parts are identified by data attributes instead —
+v11 is unstyled-first: outside styled mode (§6), PrimeReact elements carry **no `p-*`
+class at all**. Parts are identified by data attributes instead —
 `[data-scope="dialog"][data-part="close"]`, `[data-scope="select"][data-part="trigger"]`,
-and so on. Selectors written against v10 class names will silently match nothing. (`pt`
-slot keys are unaffected.)
+and so on. Selectors written against v10 class names will silently match nothing there. In
+styled mode the `p-*` class names are back — `styledMode()` applies PrimeReact's component
+styles to every primitive — and the theme sits in the `primereact` cascade layer, so a
+plain `.p-button { … }` in your own CSS overrides it as it did on v10. (`pt` slot keys are
+unaffected either way.)
 
 ## 10. What's new (nothing to migrate — just available)
 
@@ -317,7 +377,17 @@ slot keys are unaffected.)
 - **CommandForm fields** — `PasswordField`, `ToggleSwitchField`, `RatingField`.
 - **`AutoCommandForm`** — generates a `CommandForm`'s fields from the command's own
   `propertyDescriptors`, with a `registerFieldTypeProvider` registry for custom types.
-- **`@cratis/components/theme`** — the Cratis baseline theme, MIT CSS (§6).
+- **`@cratis/components/theme`** — the Cratis baseline theme, MIT CSS (§6). It now
+  positions the dialog backdrop and positioner itself; previously a baseline-theme dialog
+  could render below the page content.
+- **`@cratis/components/styled`** — `styledMode()`, `CratisPreset`, `primeReactStyles`,
+  `primeReactCssLayer` and `cratisDarkModeSelector`: PrimeReact's styled mode, wired for
+  the provider (§6).
+- **`@cratis/components/primereact-v10-palette`** — the PrimeReact 10 theme variables
+  (`--surface-*`, `--text-color`, `--primary-color`, the color scales, …) restored with the
+  lara-blue values, for CSS already written against them (§6).
+- **`Dropdown`** reads `label` / `value` off option objects when `optionLabel` /
+  `optionValue` are omitted — the v10 `Dropdown` convention (§9).
 
 ---
 
@@ -330,7 +400,7 @@ upgrade, and it is not a theming detail — it applies to the whole library.
 |---|---|---|
 | `primereact` | MIT | PrimeUI commercial |
 | `primeicons` | MIT (7.x) | PrimeUI commercial (8.x) |
-| `@primereact/core`, `@primereact/headless` | — | PrimeUI commercial |
+| `@primereact/core`, `@primereact/headless`, `@primereact/styles` | — | PrimeUI commercial |
 | `@primeuix/themes`, `@primeuix/styled` | — | PrimeUI commercial |
 
 From PrimeReact 11's own `LICENSE.md`: *"A valid license key is required to use this
@@ -361,7 +431,8 @@ production. Supply your key through the provider:
 ```
 
 What the styling choice *does* change is whether you additionally pull in
-`@primeuix/themes`. `@cratis/components/theme` is Cratis-authored MIT CSS that embeds no
+`@primereact/styles` and `@primeuix/themes` — both PrimeUI-licensed too, and needed only
+for styled mode. `@cratis/components/theme` is Cratis-authored MIT CSS that embeds no
 PrimeTek values — so that **stylesheet** carries no PrimeTek terms, but rendering it still
 means running PrimeReact 11, which needs a key.
 

--- a/Source/README.md
+++ b/Source/README.md
@@ -49,8 +49,8 @@ The other **peer dependencies** you provide are `react` / `react-dom` (**19+**),
 `@cratis/arc*` packages (`>=20.3.1 <22` — Arc 20 and 21 both work), `reflect-metadata`
 and `tsyringe`; you typically already have these in a Cratis app. `pixi.js`,
 `framer-motion`, `allotment` and `react-icons` remain regular dependencies and are
-installed for you. The styled `@primeuix/themes` presets are optional and only needed
-if you opt into a preset (see [Styling](#styling)).
+installed for you. `@primereact/styles` and `@primeuix/themes` are **optional** peers,
+needed only for PrimeReact's styled mode (see [Styling](#styling)).
 
 ### Stylesheets
 
@@ -76,12 +76,13 @@ packages it brings with it.
 |---|---|---|
 | `primereact` | MIT | PrimeUI commercial |
 | `primeicons` | MIT (7.x) | PrimeUI commercial (8.x) |
-| `@primereact/core`, `@primereact/headless` | — | PrimeUI commercial |
+| `@primereact/core`, `@primereact/headless`, `@primereact/styles` | — | PrimeUI commercial |
 | `@primeuix/themes`, `@primeuix/styled` | — | PrimeUI commercial |
 
 `@cratis/components` itself remains **MIT**. The change is in what it depends on, and it is
 yours to satisfy: PrimeReact is a peer dependency, so you install it and its license terms
-apply to you directly.
+apply to you directly. `@primereact/styles` and `@primeuix/themes` — the two styled mode
+adds — are PrimeUI-licensed too.
 
 ### A key is required regardless of how you style
 
@@ -168,13 +169,15 @@ Components:
 - `@cratis/components/SchemaEditor`
 - `@cratis/components/TimeMachine`
 - `@cratis/components/Toolbar`
+- `@cratis/components/styled` — `styledMode`, `CratisPreset`, `primeReactStyles`, `primeReactCssLayer`, `primeReactCssLayerOrder`, `cratisDarkModeSelector`: PrimeReact's styled mode, wired for the provider (needs `@primereact/styles` + `@primeuix/themes`)
 - `@cratis/components/types`
 
 Stylesheets:
 
-- `@cratis/components/theme` — the **Cratis baseline theme** (light + dark, Cratis-authored MIT CSS, no `@primeuix/themes` dependency); import it and add `class="cratis-theme"` to skin every component from the token layer
+- `@cratis/components/theme` — the **Cratis baseline theme** (light + dark, Cratis-authored MIT CSS, no `@primereact/styles` / `@primeuix/themes` dependency); import it and add `class="cratis-theme"` to skin every component from the token layer
 - `@cratis/components/styles` — **required**: every component stylesheet, the Tailwind utilities used inside the package, and the `allotment` rules `DataPage` needs, in one file
 - `@cratis/components/tokens` — **required**: the `--cratis-*` CSS variable tokens every component reads from
+- `@cratis/components/primereact-v10-palette` — the PrimeReact 10 theme variables (`--surface-*`, `--text-color`, `--primary-color`, the color scales, …) restored with the lara-blue values, for CSS already written against them
 
 ## Styling
 
@@ -198,24 +201,31 @@ much control you want, and the other layers stay invisible.
 | Setup | When | Effort | Extra dependency | What you write |
 |---|---|---|---|---|
 | **Cratis baseline theme** | You want a polished default look without adding a theme package. | Lowest | None | `unstyled` + `import '@cratis/components/theme'` + `class="cratis-theme"` |
-| **A styled `@primeuix/themes` preset** | You want a prebuilt design system to tweak from. | Low | `@primeuix/themes` | `value={{ theme: { preset } }}` on the provider |
-| **A custom palette over a preset** | You want the preset's structure but your own colors. | Low | `@primeuix/themes` | A preset + CSS variable overrides |
+| **PrimeReact's styled mode** | You want PrimeReact's own look — a `@primeuix/themes` preset painting PrimeReact's component styles. | Low | `@primereact/styles` + `@primeuix/themes` | `value={{ license, ...styledMode() }}` with `styledMode` from `@cratis/components/styled` |
+| **A custom palette over a theme** | You want the theme's structure but your own colors. | Low | As above, or none | `--cratis-*` overrides on the baseline theme, or `styledMode({ preset: definePreset(CratisPreset, …) })` |
 | **Fully unstyled** | You're integrating into a tightly controlled design system. | Highest | None | `unstyled: true` + a `pt` preset in CSS or Tailwind |
 
 > **Why you need a theme, a baseline stylesheet, or a `pt` preset**
 >
-> PrimeReact 11 is **unstyled-first**: the primitives render structural markup
-> with no built-in visuals. A look comes from one of three sources — a
-> `@primeuix/themes` preset (token-based), the Cratis baseline
-> theme (`@cratis/components/theme`), or your own `pt`/CSS. Load
-> none of them and the components render as their raw HTML primitives.
+> PrimeReact 11 is **unstyled-first**: the `primereact` package is primitives
+> that render structural markup with `data-scope` / `data-part` attributes,
+> no built-in visuals and **no `p-*` class names**. The class names and the
+> CSS behind them live in `@primereact/styles`; PrimeReact's own styled
+> components (`@primereact/ui`) are just the primitives with those styles
+> preset, and this library builds on the primitives. So a look comes from one
+> of three sources — PrimeReact's styled mode (`styledMode()`: a
+> `@primeuix/themes` preset **plus** PrimeReact's component styles), the
+> Cratis baseline theme (`@cratis/components/theme`), or your own `pt`/CSS.
+> Load none of them and the components render as their raw HTML primitives.
+> **A preset alone is not one of the three** — `theme: { preset }` by itself
+> emits `--p-*` tokens but styles nothing rendered here.
 >
 > The `--cratis-*` token layer is an **additive Cratis-scoped tint** for
 > surfaces *our* wrappers own (validation error text, the FormElement addon,
 > breadcrumb borders, etc.). It is not, by itself, enough to skin the
-> PrimeReact widgets — pair it with the baseline theme, a preset, or a `pt`
-> preset. Override the PrimeReact variables (or a preset's `--p-*` tokens) when
-> you want the whole UI in your palette.
+> PrimeReact widgets — pair it with the baseline theme, styled mode, or a `pt`
+> preset. Derive the preset (styled mode) or override the `--cratis-*` tokens
+> (baseline theme) when you want the whole UI in your palette.
 
 All setups share the same one-line provider setup. You can change direction
 later because the same provider, tokens, and `pt` hooks stay available.
@@ -245,7 +255,7 @@ export const App = () => (
   required, not optional.
 - `CratisComponentsProvider` is a thin wrapper over `@primereact/core`'s
   `PrimeReactProvider` so Cratis has one place to layer in defaults (including
-  the optional `value={{ theme: { preset } }}` styled layer). Drop in the raw
+  the optional `...styledMode()` styled layer). Drop in the raw
   `PrimeReactProvider` from `@primereact/core` if you'd rather.
 
 The setups below differ only in **what else** you load on top of this
@@ -253,39 +263,103 @@ provider setup.
 
 ---
 
-### Use a styled preset
+### Use PrimeReact's styled mode
 
 PrimeReact 11 dropped the v10 `primereact/resources/themes/*/theme.css`
-stylesheets in favor of the token-based `@primeuix/themes` layer. Apply a
-preset by passing `value={{ theme: { preset } }}` to `CratisComponentsProvider` —
-no theme CSS import. PrimeReact's own widgets paint themselves from the preset, and the
-`--cratis-*` tokens cascade to the matching variables so Cratis-scoped surfaces
-follow along.
+stylesheets. A theme is now handed to the provider at runtime, in two halves: a
+`@primeuix/themes` **preset** (a token object `@primeuix/styled` turns into
+`--p-*` custom properties) and PrimeReact's **component styles**
+(`@primereact/styles` — the `p-*` class names and the CSS the tokens drive).
+`styledMode()` from `@cratis/components/styled` returns both as
+`{ theme, defaults }`; spread it into the provider `value` next to your
+license key. The `defaults` are `primeReactStyles`, PrimeReact's component
+styles keyed by primitive name, which the provider applies to **every**
+primitive rendered under it — the ones this library renders and the ones your
+app renders itself. That is what puts the `p-*` class names on the elements and
+lets the preset paint them; the `--cratis-*` tokens follow the preset's `--p-*`
+so Cratis-scoped surfaces stay in sync.
+
+```bash
+npm install @primereact/styles @primeuix/themes   # optional peers, styled mode only
+```
 
 ```tsx
-import Aura from '@primeuix/themes/aura';   // or lara / nora / material
 import 'primeicons/primeicons.css';
+import '@cratis/components/tokens';
 import '@cratis/components/styles';
-
 import { CratisComponentsProvider } from '@cratis/components';
+import { styledMode } from '@cratis/components/styled';
 
 export const App = () => (
-    <CratisComponentsProvider value={{ theme: { preset: Aura } }}>
+    <CratisComponentsProvider value={{ license: 'YOUR-PRIMEUI-KEY', ...styledMode() }}>
         <YourApp />
     </CratisComponentsProvider>
 );
 ```
 
-Omit `theme` entirely to stay unstyled-first — ship only structure plus the
-`--cratis-*` tokens and bring your own visuals (see the pass-through / `pt`
-options below).
+The default preset is `CratisPreset` — Lara with the blue primary and gray
+surfaces of PrimeReact 10's `lara-light-blue` / `lara-dark-blue`, with the dark
+surface scale one step lighter so content sits above the page as it did there,
+both color schemes.
+Options: `preset` (any `@primeuix/themes` preset — Aura, Lara, Nora, Material —
+or a `definePreset` result), `darkModeSelector` (default `.cratis-dark`, the
+class the baseline theme uses too; `'system'` follows `prefers-color-scheme`),
+`cssLayer` (default the `primereact` layer ordered between Tailwind's `base`
+and `components`; `false` emits the theme unlayered).
+
+> **A preset alone styles nothing.** `value={{ theme: { preset } }}` without the
+> `defaults` emits the `--p-*` tokens, but the primitives keep rendering with no
+> `p-*` class, so nothing rendered by this library is painted. Use
+> `styledMode()`.
+
+#### Override a single component with CSS
+
+Plain CSS works fine on top of the theme. In styled mode PrimeReact's elements
+carry their `p-*` class names, and the theme is emitted into the `primereact`
+cascade layer, so a plain unlayered rule in your own stylesheet wins — exactly
+as it did against PrimeReact 10's `@layer primereact` stylesheets. Or target
+your own `className`:
+
+```css
+/* yourApp.css */
+.p-button {
+    border-radius: 999px;            /* pill buttons everywhere */
+}
+
+.dangerous-button {
+    background: var(--cratis-red-500);
+    color: white;
+}
+```
+
+```tsx
+<Button className="dangerous-button">Delete</Button>
+```
+
+#### Override a single component with Tailwind
+
+Pass Tailwind utility classes through the wrapper's `className` prop:
+
+```tsx
+<InputTextField value={c => c.name}
+                className="rounded-2xl bg-slate-900 text-slate-50" />
+
+<Dialog title="Confirm" className="shadow-2xl rounded-3xl">
+    {/* … */}
+</Dialog>
+```
+
+**Use this setup when:** you're prototyping, building internal tools, want the
+look Cratis apps had on PrimeReact 10, or are happy with one of the prebuilt
+PrimeReact design systems.
 
 ### Use the Cratis baseline theme
 
-Want a polished default look **without adding `@primeuix/themes`**? Ship the
-components unstyled and import the Cratis baseline theme — Cratis-authored MIT
-CSS that styles every component from the `--cratis-*` layer. (You still need a
-PrimeUI key to run PrimeReact itself — see [Licensing](#licensing).)
+Want a polished default look **without adding `@primereact/styles` and
+`@primeuix/themes`**? Ship the components unstyled and import the Cratis baseline
+theme — Cratis-authored MIT CSS that styles every component from the `--cratis-*`
+layer. (You still need a PrimeUI key to run PrimeReact itself — see
+[Licensing](#licensing).)
 
 ```tsx
 import 'primeicons/primeicons.css';
@@ -302,108 +376,89 @@ export const App = () => (
 
 Add `cratis-dark` to an ancestor for the dark palette. The theme defers to a
 `@primeuix/themes` preset's `--p-*` tokens when one is present, so you can layer
-it under a preset too, and every rule is overridable via your own CSS or `pt`.
-
-#### Override a single component with CSS
-
-Plain CSS works fine on top of the theme. Target either PrimeReact's class
-names or your own `className`:
+it under styled mode too, and every rule is overridable via your own CSS or `pt`.
+The baseline theme styles the unstyled primitives through their `[data-scope]`
+attributes — there are no `p-*` class names outside styled mode — so target
+those, or your own `className`, or the `--cratis-*` tokens:
 
 ```css
-/* yourApp.css */
-.p-button {
-    border-radius: 999px;            /* pill buttons everywhere */
-}
-
-.dangerous-button {
-    background: var(--cratis-red-500);
-    color: white;
-}
+.cratis-theme [data-scope='button'] { border-radius: 999px; }   /* pill buttons */
+.dangerous { background: var(--cratis-red-500); color: white; }
 ```
-
-```tsx
-<Button label="Delete" className="dangerous-button" />
-```
-
-#### Override a single component with Tailwind
-
-Pass Tailwind utility classes through the wrapper's `className` prop:
-
-```tsx
-<InputTextField value={c => c.name}
-                className="rounded-2xl bg-slate-900 text-slate-50" />
-
-<Dialog title="Confirm" className="shadow-2xl rounded-3xl">
-    {/* … */}
-</Dialog>
-```
-
-**Use this setup when:** you're prototyping, building internal tools, or are
-happy with one of the prebuilt PrimeReact themes.
 
 ---
 
 ### Use a custom palette on top of a PrimeReact theme
 
-Keep a PrimeReact theme as your **structural baseline** (so every widget gets
-its padding, dialog frame, button shape, focus ring, etc.) and override the
-PrimeReact CSS variables on `:root` to repaint the whole UI in your own
-colors. The `--cratis-*` tokens follow along through tokens.css's cascade, so
-Cratis-scoped surfaces stay in sync — and you can override the Cratis tokens
-independently if you want Cratis surfaces to differ from PrimeReact widgets.
+Keep a theme as your **structural baseline** (so every widget gets its
+padding, dialog frame, button shape, focus ring, etc.) and repaint it with your
+own colors. Which knob you turn depends on the theme:
 
-#### With plain CSS
+- **Cratis baseline theme** — override the `--cratis-*` tokens in CSS; the
+  theme paints the widgets from them, so one override repaints widgets and
+  Cratis-scoped surfaces alike.
+- **PrimeReact's styled mode** — derive your own preset with `definePreset` and
+  hand it to `styledMode({ preset })`; the widgets read the preset's `--p-*`
+  tokens, and the `--cratis-*` tokens follow.
+
+#### Baseline theme, plain CSS
 
 ```css
-/* palette.override.css — imported once, after @cratis/components/styles */
-:root {
-    /* PrimeReact variables — these are what PrimeReact widgets read. */
-    --surface-0:        #1e293b;
-    --surface-100:      #1e293b;
-    --surface-ground:   #020617;
-    --surface-section:  #0f172a;
-    --surface-card:     #1e293b;
-    --surface-overlay:  #1e293b;
-    --surface-hover:    #334155;
-    --surface-border:   #334155;
+/* palette.override.css — imported once, after @cratis/components/theme */
+.cratis-theme {
+    --cratis-surface-section: #0f172a;
+    --cratis-surface-card:    #1e293b;
+    --cratis-surface-overlay: #1e293b;
+    --cratis-surface-hover:   #334155;
+    --cratis-surface-border:  #334155;
 
-    --text-color:           #f8fafc;
-    --text-color-secondary: #94a3b8;
+    --cratis-text-color:           #f8fafc;
+    --cratis-text-color-secondary: #94a3b8;
 
-    --primary-color:      #38bdf8;
-    --primary-color-text: #0b1220;
+    --cratis-primary-color:      #38bdf8;
+    --cratis-primary-color-text: #0b1220;
 
-    --highlight-bg:         #1e40af;
-    --highlight-text-color: #ffffff;
+    --cratis-highlight-bg:         #1e40af;
+    --cratis-highlight-text-color: #ffffff;
 
-    --border-radius: 10px;
-
-    /* --cratis-* tokens default to var(--surface-*) etc. via tokens.css, so
-       the overrides above flow through automatically. Set these explicitly
-       only if you want Cratis-scoped surfaces tinted differently. */
-    --cratis-red-500:   #ef4444;
-    --cratis-green-500: #22c55e;
+    --cratis-border-radius: 10px;
 }
 ```
 
+#### Styled mode, `definePreset`
+
+```ts
+// brand-preset.ts
+import { definePreset } from '@primeuix/themes';
+import { CratisPreset } from '@cratis/components/styled';
+
+export const BrandPreset = definePreset(CratisPreset, {
+    semantic: {
+        primary: {
+            50: '{sky.50}',   100: '{sky.100}', 200: '{sky.200}',
+            300: '{sky.300}', 400: '{sky.400}', 500: '{sky.500}',
+            600: '{sky.600}', 700: '{sky.700}', 800: '{sky.800}',
+            900: '{sky.900}', 950: '{sky.950}',
+        },
+    },
+});
+```
+
 ```tsx
-// 1. A styled preset provides the structure (apply it via the provider — see above).
-import 'primeicons/primeicons.css';
-import '@cratis/components/styles';
-// 2. Your palette overrides — must come after the styles so they win.
-import './palette.override.css';
+<CratisComponentsProvider value={{ license, ...styledMode({ preset: BrandPreset }) }}>
 ```
 
 #### Scoped (dark-on-light, light-on-dark, etc.)
 
-PrimeReact variables cascade like any other CSS variable, so an ancestor
-scope works:
+`--cratis-*` tokens cascade like any other CSS variable, so an ancestor scope
+works under the baseline theme (in styled mode, region-scoped widget colors come
+from the preset; the `--cratis-*` overrides still retint Cratis-scoped surfaces):
 
 ```css
 .dark-zone {
-    --surface-card: #0b1220;
-    --text-color:   #f8fafc;
-    --primary-color: #60a5fa;
+    --cratis-surface-card:  #0b1220;
+    --cratis-text-color:    #f8fafc;
+    --cratis-primary-color: #60a5fa;
 }
 ```
 
@@ -421,37 +476,54 @@ Tailwind handles cascade and dark mode:
 ```css
 /* app.css */
 @import "tailwindcss";
+@import "@cratis/components/tokens";
 @import "@cratis/components/styles";
 
 @layer base {
     :root {
-        --surface-card:   theme('colors.slate.800');
-        --surface-border: theme('colors.slate.700');
-        --text-color:     theme('colors.slate.50');
-        --primary-color:  theme('colors.sky.400');
-        --cratis-red-500: theme('colors.red.500');
+        --cratis-surface-card:   theme('colors.slate.800');
+        --cratis-surface-border: theme('colors.slate.700');
+        --cratis-text-color:     theme('colors.slate.50');
+        --cratis-primary-color:  theme('colors.sky.400');
+        --cratis-red-500:        theme('colors.red.500');
     }
 
-    .dark {
-        --surface-card: theme('colors.slate.900');
-        --text-color:   theme('colors.slate.100');
+    .cratis-dark {
+        --cratis-surface-card: theme('colors.slate.900');
+        --cratis-text-color:   theme('colors.slate.100');
     }
 }
 ```
 
+#### CSS written against PrimeReact 10's variables
+
+If your stylesheets still use the names a v10 theme published on `:root` —
+`--surface-ground`, `--surface-card`, `--surface-border`, `--text-color`,
+`--primary-color`, the `--surface-0…900` and color scales — import
+`@cratis/components/primereact-v10-palette` after `tokens` and `styles`. It
+restores every one of them with the `lara-light-blue` / `lara-dark-blue`
+values: the semantic names follow the active preset's `--p-*` tokens where
+v11 has an equivalent (Lara as the fallback), the numbered scales are the
+lara-blue values verbatim (the v10 dark surface scale was inverted, so
+`--p-surface-*` cannot stand in for it), and light/dark switch through
+`light-dark()` keyed off `.cratis-dark`. It exists so what is already written
+keeps working — write nothing new against those names; use `--cratis-*` (or
+`--p-*`).
+
 #### What `--cratis-*` tokens are for
 
-PrimeReact widgets read PrimeReact's own variables (`--surface-card`,
-`--text-color`, `--primary-color`, …) directly. Cratis wrappers add some
-surfaces of their own (inline validation error text, the FormElement addon
-background, the breadcrumb bottom border, etc.) — those use a parallel set
-of `--cratis-*` tokens that default to the PrimeReact value via the cascade
-defined in `tokens.css`.
+In styled mode PrimeReact widgets read the preset's `--p-*` design tokens
+directly. Cratis wrappers add some surfaces of their own (inline validation
+error text, the FormElement addon background, the breadcrumb bottom border,
+etc.) — those use a parallel set of `--cratis-*` tokens that resolve the v11
+token first and fall back to the v10 variable, via the cascade defined in
+`tokens.css`. Under the baseline theme the widgets read the `--cratis-*` tokens
+too.
 
 The upshot:
 
-- Override **PrimeReact variables** to repaint the whole UI (PrimeReact widgets + Cratis surfaces).
-- Override **`--cratis-*` tokens** when you specifically want Cratis surfaces to differ from PrimeReact widgets.
+- Repaint the whole UI by deriving the **preset** (styled mode) or overriding the **`--cratis-*` tokens** (baseline theme).
+- Override **`--cratis-*` tokens** in styled mode when you specifically want Cratis surfaces to differ from PrimeReact widgets.
 
 #### `--cratis-*` token reference (Cratis-scoped surfaces)
 
@@ -465,8 +537,9 @@ The upshot:
 | Geometry | `--cratis-border-radius` |
 | Effects | `--cratis-focus-ring`, `--cratis-maskbg` |
 
-Each defaults to the PrimeReact variable with the same name minus the
-`--cratis-` prefix (e.g. `--cratis-surface-card` → `var(--surface-card)`).
+Each resolves the v11 design token first and falls back to the v10 variable
+with the same name minus the `--cratis-` prefix (e.g. `--cratis-surface-card`
+→ `var(--p-content-background, var(--surface-card))`).
 
 **Use this setup when:** you want a custom look without writing a PrimeReact
 theme from scratch, you're shipping multiple palette variants (light/dark/
@@ -614,20 +687,22 @@ The styling options compose, so you don't have to choose one for the whole app:
   ```tsx
   <Dialog title="Custom" unstyled pt={brandDialogPt}>…</Dialog>
   ```
-- **Unstyled with one themed island** — wrap a subtree in a second
-  `CratisComponentsProvider` that restores defaults:
+- **Unstyled with one themed island** — the baseline theme's rules are scoped
+  under `.cratis-theme`, so wrapping one element in the class themes just that
+  subtree:
   ```tsx
   <CratisComponentsProvider value={{ unstyled: true, pt: globalPt }}>
       <App />
-      <CratisComponentsProvider value={{ unstyled: false }}>
-          <PrimeReactThemedSubtree />
-      </CratisComponentsProvider>
+      <div className="cratis-theme">
+          <BaselineThemedSubtree />
+      </div>
   </CratisComponentsProvider>
   ```
-- **Dark mode** — scope the palette overrides to `.dark` (override
-  `--surface-card`, `--text-color`, `--primary-color`, etc., plus any
-  `--cratis-*` tokens you want to diverge) and toggle the class on the root
-  element. PrimeReact widgets and Cratis surfaces both follow the cascade.
+- **Dark mode** — toggle `cratis-dark` on the root element: the baseline
+  theme's dark palette, `styledMode()`'s dark scheme (its default
+  `darkModeSelector`) and the v10 palette all key off it, so PrimeReact widgets
+  and Cratis surfaces follow together. Scope any `--cratis-*` tokens you want
+  to diverge to `.cratis-dark` as well.
 
 ### Per-component `pt` cheat sheet
 

--- a/Source/Styled/CratisPreset.ts
+++ b/Source/Styled/CratisPreset.ts
@@ -1,0 +1,78 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { definePreset } from '@primeuix/themes';
+import Lara from '@primeuix/themes/lara';
+
+/**
+ * A `@primeuix/themes` preset with the look Cratis applications had on PrimeReact 10.
+ *
+ * Every Cratis application shipped `lara-dark-blue` (and `lara-light-blue` where a light
+ * scheme was offered). Lara is still PrimeReact's design system in version 11, so this
+ * starts from it and moves the palette back to what those themes used: a blue primary
+ * over gray surfaces.
+ *
+ * The dark surface scale is shifted one step lighter than the light one. Lara's dark
+ * scheme places content on `surface.900`, form fields and the page on `surface.950`, and
+ * borders and hovers on `surface.800`; the v10 dark theme had cards, tables, dialogs and
+ * dropdown panels on `#1f2937` (gray 800) over a `#111827` (gray 900) page, with inputs on
+ * the page tone. Mapping dark `surface.900` to gray 800 and `surface.950` to gray 900
+ * reproduces exactly that through Lara's own component tokens, without overriding any
+ * of them — so borders, hovers and selection stay one visible step apart from the
+ * surfaces they sit on.
+ *
+ * Both color schemes are carried; which one applies follows the provider's
+ * `darkModeSelector`. Extend it the way you would any preset:
+ *
+ * ```ts
+ * import { definePreset } from '@primeuix/themes';
+ * import { CratisPreset } from '@cratis/components/styled';
+ *
+ * const MyPreset = definePreset(CratisPreset, { semantic: { primary: { ... } } });
+ * ```
+ */
+export const CratisPreset = definePreset(Lara, {
+    semantic: {
+        primary: {
+            50: '{blue.50}',
+            100: '{blue.100}',
+            200: '{blue.200}',
+            300: '{blue.300}',
+            400: '{blue.400}',
+            500: '{blue.500}',
+            600: '{blue.600}',
+            700: '{blue.700}',
+            800: '{blue.800}',
+            900: '{blue.900}',
+            950: '{blue.950}',
+        },
+        surface: {
+            0: '#ffffff',
+            50: '{gray.50}',
+            100: 'light-dark({gray.100}, {gray.50})',
+            200: 'light-dark({gray.200}, {gray.100})',
+            300: 'light-dark({gray.300}, {gray.200})',
+            400: 'light-dark({gray.400}, {gray.300})',
+            500: 'light-dark({gray.500}, {gray.400})',
+            600: 'light-dark({gray.600}, {gray.500})',
+            700: 'light-dark({gray.700}, {gray.600})',
+            800: 'light-dark({gray.800}, {gray.700})',
+            900: 'light-dark({gray.900}, {gray.800})',
+            950: 'light-dark({gray.950}, {gray.900})',
+        },
+    },
+    components: {
+        // Lara raises a table's head and foot one step above its rows; the v10 dark theme
+        // kept them on the row tone and told them apart by weight and a border, as the
+        // Workbench and Studio tables were designed around.
+        datatable: {
+            header: { background: 'light-dark({surface.50}, {content.background})' },
+            headerCell: {
+                background: 'light-dark({surface.50}, {content.background})',
+                selectedBackground: 'light-dark({surface.50}, {content.background})',
+            },
+            footer: { background: 'light-dark({surface.50}, {content.background})' },
+            footerCell: { background: 'light-dark({surface.50}, {content.background})' },
+        },
+    },
+});

--- a/Source/Styled/for_primeReactStyles/when_resolving_the_styles_of_every_primitive.ts
+++ b/Source/Styled/for_primeReactStyles/when_resolving_the_styles_of_every_primitive.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { primeReactStyles } from '../primeReactStyles';
+
+type Entry = { props: { styles?: { name: string; classes: unknown }; motionProps?: { name: string } } };
+
+describe('when resolving the styles of every primitive', () => {
+    const entries = Object.entries(primeReactStyles) as [string, Entry][];
+    const roots = entries.filter(([, entry]) => entry.props.styles);
+    const motionOnly = entries.filter(([, entry]) => !entry.props.styles);
+
+    it('should have an entry for every primitive this library renders', () => {
+        for (const name of [
+            'Button', 'InputText', 'Textarea', 'InputPassword',
+            'Checkbox.Root', 'RadioButton.Root', 'ToggleSwitch.Root', 'Slider.Root', 'Rating.Root',
+            'InputNumber.Root', 'InputTags.Root', 'InputColor.Root', 'DatePicker.Root', 'Select.Root',
+            'DataTable.Root', 'Dialog.Root', 'Popover.Root', 'Stepper.Root', 'Tooltip.Root',
+            'Toast.Root', 'Toaster.Root', 'Message.Root', 'Tag', 'Badge', 'Chip.Root', 'Avatar.Root',
+            'Skeleton', 'ProgressBar.Root', 'ProgressSpinner.Root', 'Timeline.Root',
+        ]) {
+            primeReactStyles.should.have.property(name);
+        }
+    });
+
+    it('should give every root a named PrimeReact style with class names', () => {
+        roots.should.not.be.empty;
+        for (const [, entry] of roots) {
+            entry.props.styles!.name.should.be.a('string').and.not.be.empty;
+            entry.props.styles!.should.have.property('classes');
+        }
+    });
+
+    it('should name the motion of every part that only animates', () => {
+        motionOnly.should.not.be.empty;
+        for (const [, entry] of motionOnly) {
+            entry.props.motionProps!.name.should.match(/^p-/);
+        }
+    });
+
+    it('should key every entry on a primitive component name', () => {
+        for (const [name] of entries) {
+            name.should.match(/^[A-Z][A-Za-z]+(\.[A-Z][A-Za-z]+)?$/);
+        }
+    });
+});

--- a/Source/Styled/for_styledMode/when_configuring_with_defaults.ts
+++ b/Source/Styled/for_styledMode/when_configuring_with_defaults.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { CratisPreset } from '../CratisPreset';
+import { primeReactStyles } from '../primeReactStyles';
+import { cratisDarkModeSelector, primeReactCssLayer, primeReactCssLayerOrder, styledMode } from '../styledMode';
+
+describe('when configuring with defaults', () => {
+    let config: ReturnType<typeof styledMode>;
+
+    beforeEach(() => {
+        config = styledMode();
+    });
+
+    it('should style with the Cratis preset', () => {
+        config.theme!.preset!.should.equal(CratisPreset);
+    });
+
+    it('should switch dark mode on the Cratis dark class', () => {
+        config.theme!.options!.darkModeSelector!.should.equal(cratisDarkModeSelector);
+    });
+
+    it('should emit the theme into the primereact cascade layer', () => {
+        (config.theme!.options!.cssLayer as { name: string }).name.should.equal(primeReactCssLayer);
+    });
+
+    it('should order the layer above the base reset and below utilities', () => {
+        (config.theme!.options!.cssLayer as { order: string }).order.should.equal(primeReactCssLayerOrder);
+    });
+
+    it('should hand every primitive its PrimeReact styles', () => {
+        config.defaults!.should.equal(primeReactStyles);
+    });
+});

--- a/Source/Styled/for_styledMode/when_configuring_with_options.ts
+++ b/Source/Styled/for_styledMode/when_configuring_with_options.ts
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { primeReactStyles } from '../primeReactStyles';
+import { styledMode } from '../styledMode';
+
+describe('when configuring with options', () => {
+    const preset = { primitive: {}, semantic: {} };
+
+    it('should style with the given preset', () => {
+        styledMode({ preset }).theme!.preset!.should.equal(preset);
+    });
+
+    it('should switch dark mode on the given selector', () => {
+        styledMode({ darkModeSelector: '.app-dark' }).theme!.options!.darkModeSelector!.should.equal('.app-dark');
+    });
+
+    it('should follow the system scheme when asked to', () => {
+        styledMode({ darkModeSelector: 'system' }).theme!.options!.darkModeSelector!.should.equal('system');
+    });
+
+    it('should name the cascade layer from a string', () => {
+        (styledMode({ cssLayer: 'ui' }).theme!.options!.cssLayer as { name: string }).name.should.equal('ui');
+    });
+
+    it('should keep the default order with the layer renamed', () => {
+        (styledMode({ cssLayer: 'ui' }).theme!.options!.cssLayer as { order: string }).order.should.equal('theme, base, ui, components, utilities');
+    });
+
+    it('should pass a layer with an order through untouched', () => {
+        const cssLayer = { name: 'ui', order: 'reset, ui, app' };
+        styledMode({ cssLayer }).theme!.options!.cssLayer!.should.equal(cssLayer);
+    });
+
+    it('should emit the theme unlayered when asked to', () => {
+        styledMode({ cssLayer: false }).theme!.options!.cssLayer!.should.equal(false);
+    });
+
+    it('should still hand every primitive its PrimeReact styles', () => {
+        styledMode({ preset }).defaults!.should.equal(primeReactStyles);
+    });
+});

--- a/Source/Styled/index.ts
+++ b/Source/Styled/index.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+export * from './CratisPreset';
+export * from './primeReactStyles';
+export * from './styledMode';

--- a/Source/Styled/primeReactStyles.ts
+++ b/Source/Styled/primeReactStyles.ts
@@ -1,0 +1,204 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import type { ComponentDefaults } from '@primereact/types/core';
+import { styles as accordion } from '@primereact/styles/accordion';
+import { styles as autocomplete } from '@primereact/styles/autocomplete';
+import { styles as avatar } from '@primereact/styles/avatar';
+import { styles as avatarGroup } from '@primereact/styles/avatargroup';
+import { styles as badge } from '@primereact/styles/badge';
+import { styles as breadcrumb } from '@primereact/styles/breadcrumb';
+import { styles as button } from '@primereact/styles/button';
+import { styles as buttonGroup } from '@primereact/styles/buttongroup';
+import { styles as card } from '@primereact/styles/card';
+import { styles as carousel } from '@primereact/styles/carousel';
+import { styles as checkbox } from '@primereact/styles/checkbox';
+import { styles as checkboxGroup } from '@primereact/styles/checkboxgroup';
+import { styles as chip } from '@primereact/styles/chip';
+import { styles as compare } from '@primereact/styles/compare';
+import { styles as contextMenu } from '@primereact/styles/contextmenu';
+import { styles as dataTable } from '@primereact/styles/datatable';
+import { styles as dataView } from '@primereact/styles/dataview';
+import { styles as datePicker } from '@primereact/styles/datepicker';
+import { styles as dialog } from '@primereact/styles/dialog';
+import { styles as divider } from '@primereact/styles/divider';
+import { styles as drawer } from '@primereact/styles/drawer';
+import { styles as fieldset } from '@primereact/styles/fieldset';
+import { styles as fileUpload } from '@primereact/styles/fileupload';
+import { styles as floatLabel } from '@primereact/styles/floatlabel';
+import { styles as fluid } from '@primereact/styles/fluid';
+import { styles as gallery } from '@primereact/styles/gallery';
+import { styles as iconField } from '@primereact/styles/iconfield';
+import { styles as iftaLabel } from '@primereact/styles/iftalabel';
+import { styles as inplace } from '@primereact/styles/inplace';
+import { styles as inputColor } from '@primereact/styles/inputcolor';
+import { styles as inputGroup } from '@primereact/styles/inputgroup';
+import { styles as inputNumber } from '@primereact/styles/inputnumber';
+import { styles as inputOtp } from '@primereact/styles/inputotp';
+import { styles as inputTags } from '@primereact/styles/inputtags';
+import { styles as inputText } from '@primereact/styles/inputtext';
+import { styles as knob } from '@primereact/styles/knob';
+import { styles as label } from '@primereact/styles/label';
+import { styles as listbox } from '@primereact/styles/listbox';
+import { styles as menu } from '@primereact/styles/menu';
+import { styles as message } from '@primereact/styles/message';
+import { styles as meterGroup } from '@primereact/styles/metergroup';
+import { styles as navigationMenu } from '@primereact/styles/navigationmenu';
+import { styles as organizationChart } from '@primereact/styles/organizationchart';
+import { styles as overlayBadge } from '@primereact/styles/overlaybadge';
+import { styles as paginator } from '@primereact/styles/paginator';
+import { styles as panel } from '@primereact/styles/panel';
+import { styles as password } from '@primereact/styles/password';
+import { styles as popover } from '@primereact/styles/popover';
+import { styles as progressBar } from '@primereact/styles/progressbar';
+import { styles as progressSpinner } from '@primereact/styles/progressspinner';
+import { styles as radioButton } from '@primereact/styles/radiobutton';
+import { styles as radioButtonGroup } from '@primereact/styles/radiobuttongroup';
+import { styles as rating } from '@primereact/styles/rating';
+import { styles as scrollArea } from '@primereact/styles/scrollarea';
+import { styles as select } from '@primereact/styles/select';
+import { styles as sidebar, layoutStyles as sidebarLayout } from '@primereact/styles/sidebar';
+import { styles as skeleton } from '@primereact/styles/skeleton';
+import { styles as slider } from '@primereact/styles/slider';
+import { styles as speedDial } from '@primereact/styles/speeddial';
+import { styles as splitter } from '@primereact/styles/splitter';
+import { styles as stepper } from '@primereact/styles/stepper';
+import { styles as tabs } from '@primereact/styles/tabs';
+import { styles as tag } from '@primereact/styles/tag';
+import { styles as terminal } from '@primereact/styles/terminal';
+import { styles as textarea } from '@primereact/styles/textarea';
+import { styles as timeline } from '@primereact/styles/timeline';
+import { styles as toast } from '@primereact/styles/toast';
+import { styles as toaster } from '@primereact/styles/toaster';
+import { styles as toggleButton } from '@primereact/styles/togglebutton';
+import { styles as toggleButtonGroup } from '@primereact/styles/togglebuttongroup';
+import { styles as toggleSwitch } from '@primereact/styles/toggleswitch';
+import { styles as toolbar } from '@primereact/styles/toolbar';
+import { styles as tooltip } from '@primereact/styles/tooltip';
+import { styles as tree } from '@primereact/styles/tree';
+
+/**
+ * The names PrimeReact's motion hook uses for the enter/leave classes of an overlay or
+ * collapsible part. `@primereact/ui` hands these to the same primitives when it composes
+ * its styled components; the theme's transitions key off them.
+ */
+const anchoredOverlay = 'p-anchored-overlay';
+const collapsible = 'p-collapsible';
+const overlayMask = 'p-overlay-mask';
+
+/** A root that carries a component's `styles`, optionally with the motion its parts animate through. */
+const styled = (styles: unknown, motion?: string) => ({ props: motion ? { styles, motionProps: { name: motion } } : { styles } });
+
+/** A part that only needs its motion name — its classes come from the root's `styles`. */
+const motion = (name: string) => ({ props: { motionProps: { name } } });
+
+/**
+ * PrimeReact 11's own component styles, keyed by primitive component name, ready to be
+ * handed to the provider as `defaults`.
+ *
+ * PrimeReact 11 splits every component in two: the `primereact/*` primitives, which own
+ * behavior and render structural markup with `data-scope` / `data-part` attributes and no
+ * class names, and `@primereact/styles/*`, which holds the `p-*` class names and the CSS
+ * that a `@primeuix/themes` preset drives. `@primereact/ui/*` is nothing more than the two
+ * glued together: each styled component is the primitive with its `styles` prop preset.
+ *
+ * `@cratis/components` builds on the primitives, so a preset alone leaves it unstyled.
+ * PrimeReact's provider accepts default props per component name (`defaults`), and
+ * `styles` is a public prop on every primitive, so this map performs the same gluing
+ * `@primereact/ui` does — for every primitive rendered under the provider, whether by
+ * this library or by the application. Together with a preset it is styled mode. Prefer
+ * {@link styledMode}, which combines the two.
+ *
+ * Every entry keys the primitive's *root* name (`Dialog.Root`, `Button`), because the
+ * parts read their class names from the root's styles. The overlay/collapsible parts
+ * that animate are also listed, with the motion name the theme's transitions expect.
+ */
+export const primeReactStyles: ComponentDefaults = {
+    'Accordion.Root': styled(accordion, collapsible),
+    'AutoComplete.Root': styled(autocomplete),
+    'AutoComplete.Popup': motion(anchoredOverlay),
+    'Avatar.Root': styled(avatar),
+    'AvatarGroup': styled(avatarGroup),
+    'Badge': styled(badge),
+    'Breadcrumb.Root': styled(breadcrumb),
+    'Button': styled(button),
+    'ButtonGroup': styled(buttonGroup),
+    'Card.Root': styled(card),
+    'Carousel.Root': styled(carousel),
+    'Checkbox.Root': styled(checkbox),
+    'CheckboxGroup': styled(checkboxGroup),
+    'Chip.Root': styled(chip),
+    'Compare.Root': styled(compare),
+    'ContextMenu.Root': styled(contextMenu),
+    'ContextMenu.Popup': motion(anchoredOverlay),
+    'DataTable.Root': styled(dataTable),
+    'DataView.Root': styled(dataView),
+    'DatePicker.Root': styled(datePicker),
+    'DatePicker.Popup': motion(anchoredOverlay),
+    'Dialog.Root': styled(dialog),
+    'Dialog.Backdrop': motion(overlayMask),
+    'Dialog.Popup': motion('p-dialog'),
+    'Divider': styled(divider),
+    'Drawer.Root': styled(drawer),
+    'Drawer.Backdrop': motion(overlayMask),
+    'Drawer.Popup': motion('p-drawer'),
+    'Fieldset.Root': styled(fieldset, collapsible),
+    'FileUpload.Root': styled(fileUpload),
+    'FloatLabel': styled(floatLabel),
+    'Fluid': styled(fluid),
+    'Gallery.Root': styled(gallery),
+    'IconField.Root': styled(iconField),
+    'IftaLabel': styled(iftaLabel),
+    'Inplace.Root': styled(inplace),
+    'InputColor.Root': styled(inputColor),
+    'InputGroup.Root': styled(inputGroup),
+    'InputNumber.Root': styled(inputNumber),
+    'InputOtp.Root': styled(inputOtp),
+    'InputPassword': styled(password),
+    'InputTags.Root': styled(inputTags),
+    'InputText': styled(inputText),
+    'Knob.Root': styled(knob),
+    'Label': styled(label),
+    'Listbox.Root': styled(listbox),
+    'Menu.Root': styled(menu),
+    'Menu.Popup': motion(anchoredOverlay),
+    'Message.Root': styled(message),
+    'MeterGroup.Root': styled(meterGroup),
+    'NavigationMenu': styled(navigationMenu),
+    'OrganizationChart.Root': styled(organizationChart),
+    'OverlayBadge': styled(overlayBadge),
+    'Paginator.Root': styled(paginator),
+    'Panel.Root': styled(panel, collapsible),
+    'Popover.Root': styled(popover),
+    'Popover.Popup': motion(anchoredOverlay),
+    'ProgressBar.Root': styled(progressBar),
+    'ProgressSpinner.Root': styled(progressSpinner),
+    'RadioButton.Root': styled(radioButton),
+    'RadioButtonGroup': styled(radioButtonGroup),
+    'Rating.Root': styled(rating),
+    'ScrollArea.Root': styled(scrollArea),
+    'Select.Root': styled(select),
+    'Select.Popup': motion(anchoredOverlay),
+    'Sidebar.Root': styled(sidebar),
+    'Sidebar.Layout': styled(sidebarLayout),
+    'Sidebar.Backdrop': motion(overlayMask),
+    'Skeleton': styled(skeleton),
+    'Slider.Root': styled(slider),
+    'SpeedDial.Root': styled(speedDial),
+    'Splitter.Root': styled(splitter),
+    'Stepper.Root': styled(stepper, collapsible),
+    'Tabs.Root': styled(tabs),
+    'Tag': styled(tag),
+    'Terminal.Root': styled(terminal),
+    'Textarea': styled(textarea),
+    'Timeline.Root': styled(timeline),
+    'Toast.Root': styled(toast),
+    'Toaster.Root': styled(toaster),
+    'ToggleButton.Root': styled(toggleButton),
+    'ToggleButtonGroup': styled(toggleButtonGroup),
+    'ToggleSwitch.Root': styled(toggleSwitch),
+    'Toolbar.Root': styled(toolbar),
+    'Tooltip.Root': styled(tooltip),
+    'Tooltip.Popup': motion('p-tooltip'),
+    'Tree.Root': styled(tree),
+};

--- a/Source/Styled/styledMode.ts
+++ b/Source/Styled/styledMode.ts
@@ -1,0 +1,98 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import type { CSSLayer, ThemeOptions } from '@primereact/types/core';
+import type { CratisComponentsConfig } from '../Common/CratisComponentsProvider';
+import { CratisPreset } from './CratisPreset';
+import { primeReactStyles } from './primeReactStyles';
+
+/**
+ * The cascade layer PrimeReact's theme is emitted into by default. Rules in a layer lose
+ * to unlayered rules regardless of specificity or order, which is what lets an
+ * application's own stylesheet override the theme with a plain selector — exactly the
+ * relationship PrimeReact 10's stylesheet themes had, since they were wrapped in
+ * `@layer primereact` too.
+ */
+export const primeReactCssLayer = 'primereact';
+
+/**
+ * The layer order declared with the theme by default. PrimeReact writes its `@layer`
+ * statement ahead of every other stylesheet, so this is what fixes the order — and it
+ * has to name Tailwind's layers, which `@cratis/components/styles` declares in every
+ * consumer: the theme sits above `base`, so Tailwind's preflight reset does not strip the
+ * padding and borders the theme gives a table cell or an input, and below `components`
+ * and `utilities`, so a utility class on a PrimeReact element still wins.
+ */
+export const primeReactCssLayerOrder = 'theme, base, primereact, components, utilities';
+
+/**
+ * The selector that switches the theme to its dark scheme by default. It is the class
+ * the Cratis baseline theme keys its dark palette off as well, so one `class="cratis-dark"`
+ * on the body serves both.
+ */
+export const cratisDarkModeSelector = '.cratis-dark';
+
+export interface StyledModeOptions {
+    /**
+     * The `@primeuix/themes` preset to style with. Defaults to {@link CratisPreset}, the
+     * PrimeReact 10 look of Cratis applications; any preset — Aura, Nora, Material, or
+     * one derived with `definePreset` — works.
+     */
+    preset?: unknown;
+
+    /**
+     * How the dark scheme is activated. A selector such as `.my-dark`, `'system'` for the
+     * `prefers-color-scheme` media query, or `'none'` to stay light. Defaults to
+     * {@link cratisDarkModeSelector}.
+     */
+    darkModeSelector?: ThemeOptions['darkModeSelector'];
+
+    /**
+     * The cascade layer to emit the theme into, or `false` to emit it unlayered — in
+     * which case the theme's rules compete with the application's on specificity and
+     * order alone, and being injected at runtime they arrive last. Defaults to
+     * {@link primeReactCssLayer} ordered by {@link primeReactCssLayerOrder}. A string
+     * names the layer and keeps that order with the name swapped in; a `{ name, order }`
+     * object is used as given.
+     */
+    cssLayer?: false | string | CSSLayer;
+}
+
+/**
+ * Configures {@link CratisComponentsProvider} for PrimeReact 11's styled mode: a
+ * `@primeuix/themes` preset for the design tokens, and PrimeReact's own component styles
+ * ({@link primeReactStyles}) so every primitive — those rendered by this library and those
+ * the application renders itself — carries the `p-*` class names that preset paints.
+ *
+ * Spread the result into the provider's `value`, next to the license key and anything
+ * else the application configures:
+ *
+ * ```tsx
+ * import { CratisComponentsProvider } from '@cratis/components';
+ * import { styledMode } from '@cratis/components/styled';
+ *
+ * <CratisComponentsProvider value={{ license, ...styledMode() }}>
+ * ```
+ *
+ * The theme goes into the `primereact` cascade layer, so a plain `.p-button { … }` in the
+ * application's own stylesheet overrides it just as it did on PrimeReact 10 — see
+ * {@link primeReactCssLayerOrder} for where that layer sits relative to Tailwind's.
+ */
+export const styledMode = (options: StyledModeOptions = {}): Pick<CratisComponentsConfig, 'theme' | 'defaults'> => {
+    const cssLayer = options.cssLayer === undefined
+        ? { name: primeReactCssLayer, order: primeReactCssLayerOrder }
+        : typeof options.cssLayer === 'string'
+            ? { name: options.cssLayer, order: primeReactCssLayerOrder.replace(primeReactCssLayer, options.cssLayer) }
+            : options.cssLayer;
+
+    return {
+        theme: {
+            preset: options.preset ?? CratisPreset,
+            options: {
+                darkModeSelector: options.darkModeSelector ?? cratisDarkModeSelector,
+                cssLayer,
+            },
+        },
+        defaults: primeReactStyles,
+    };
+};

--- a/Source/package.json
+++ b/Source/package.json
@@ -106,13 +106,18 @@
             "types": "./dist/esm/Toolbar/index.d.ts",
             "import": "./dist/esm/Toolbar/index.js"
         },
+        "./styled": {
+            "types": "./dist/esm/Styled/index.d.ts",
+            "import": "./dist/esm/Styled/index.js"
+        },
         "./types": {
             "types": "./dist/esm/types/index.d.ts",
             "import": "./dist/esm/types/index.js"
         },
         "./styles": "./dist/esm/styles.css",
         "./tokens": "./dist/esm/tokens.css",
-        "./theme": "./dist/esm/theme.css"
+        "./theme": "./dist/esm/theme.css",
+        "./primereact-v10-palette": "./dist/esm/primereact-v10-palette.css"
     },
     "scripts": {
         "prepare": "yarn g:build",
@@ -140,6 +145,7 @@
         "@cratis/arc.vite": "21.19.0",
         "@primereact/core": "11.1.0",
         "@primereact/headless": "11.1.0",
+        "@primereact/styles": "11.1.0",
         "@primereact/types": "11.1.0",
         "@primeuix/motion": "^1.0.0",
         "@primeuix/styled": "^1.0.0",
@@ -153,7 +159,9 @@
         "@cratis/fundamentals": "^7.10.3",
         "@primereact/core": "^11.0.0",
         "@primereact/headless": "^11.0.0",
+        "@primereact/styles": "^11.0.0",
         "@primereact/types": "^11.0.0",
+        "@primeuix/themes": "^3.0.0",
         "primeicons": "^8.0.0",
         "primereact": "^11.0.0",
         "react": "^19.0.0",
@@ -162,7 +170,13 @@
         "tsyringe": "4.10.0"
     },
     "peerDependenciesMeta": {
+        "@primereact/styles": {
+            "optional": true
+        },
         "@primereact/types": {
+            "optional": true
+        },
+        "@primeuix/themes": {
             "optional": true
         }
     }

--- a/Source/primereact-v10-palette.css
+++ b/Source/primereact-v10-palette.css
@@ -1,0 +1,242 @@
+/* Copyright (c) Cratis. All rights reserved. */
+/* Licensed under the MIT license. See LICENSE file in the project root for full license information. */
+
+/*
+ * The PrimeReact 10 theme palette, carried forward.
+ *
+ * PrimeReact 10's stylesheet themes published a set of custom properties on `:root` —
+ * `--surface-ground`, `--surface-card`, `--surface-border`, `--text-color`, `--primary-color`,
+ * the `--surface-0…900` and `--gray/--blue/--red-…` scales, and so on — and applications wrote
+ * their own CSS against them for years. PrimeReact 11 ships no stylesheet, so those names
+ * resolve to nothing the day it is installed: borders vanish, cards lose their background,
+ * text falls back to the browser default.
+ *
+ * This file restores every one of them, with the values of the `lara-light-blue` and
+ * `lara-dark-blue` themes both Cratis applications shipped, so an application can move to
+ * PrimeReact 11 without rewriting those call sites. Import it once, next to the token layer:
+ *
+ *     import '@cratis/components/tokens';
+ *     import '@cratis/components/styles';
+ *     import '@cratis/components/primereact-v10-palette';
+ *
+ * Two kinds of name:
+ *
+ * - The **semantic** names (`--surface-ground`, `--surface-card`, `--text-color`,
+ *   `--primary-color`, …) resolve from the active `@primeuix/themes` preset's `--p-*` tokens
+ *   where PrimeReact 11 has an equivalent, so they follow whatever preset is applied — with
+ *   the Lara values as the fallback when no preset is present.
+ * - The **numbered scales** (`--surface-0…900`, `--primary-50…900`, `--gray/--blue/--red-…`)
+ *   are the Lara values verbatim. PrimeReact 11's `--p-surface-*` scale is not inverted in
+ *   dark mode the way the v10 one was, so it cannot stand in for it.
+ *
+ * Light and dark are both carried through `light-dark()`, which reads the element's
+ * `color-scheme`. `.cratis-dark` — the class the Cratis baseline theme and `styledMode()`
+ * key dark mode off — sets it, so one class on the body switches every name below.
+ *
+ * Nothing new should be written against these names: use the `--cratis-*` tokens (or the
+ * preset's `--p-*` tokens) instead. This exists so what already is written keeps working.
+ */
+
+.cratis-dark {
+    color-scheme: dark;
+}
+
+:root {
+    /* Semantic surfaces and text — follow the preset, fall back to Lara */
+    --surface-ground: light-dark(#f9fafb, #111827);
+    --surface-section: light-dark(#ffffff, #111827);
+    --surface-card: var(--p-content-background, light-dark(#ffffff, #1f2937));
+    --surface-overlay: var(--p-overlay-modal-background, light-dark(#ffffff, #1f2937));
+    --surface-border: var(--p-content-border-color, light-dark(#dfe7ef, rgba(255, 255, 255, 0.1)));
+    --surface-hover: var(--p-content-hover-background, light-dark(#f6f9fc, rgba(255, 255, 255, 0.03)));
+    --text-color: var(--p-text-color, light-dark(#4b5563, rgba(255, 255, 255, 0.87)));
+    --text-color-secondary: var(--p-text-muted-color, light-dark(#6b7280, rgba(255, 255, 255, 0.6)));
+    --primary-color: var(--p-primary-color, light-dark(#3b82f6, #60a5fa));
+    --primary-color-text: var(--p-primary-contrast-color, light-dark(#ffffff, #030712));
+    --highlight-bg: var(--p-highlight-background, light-dark(#eff6ff, rgba(96, 165, 250, 0.16)));
+    --highlight-text-color: var(--p-highlight-color, light-dark(#1d4ed8, rgba(255, 255, 255, 0.87)));
+    --focus-ring: var(--p-focus-ring-shadow, 0 0 0 0.2rem light-dark(#bfdbfe, rgba(96, 165, 250, 0.2)));
+    --maskbg: var(--p-mask-background, rgba(0, 0, 0, 0.4));
+    --border-radius: var(--p-content-border-radius, 6px);
+
+    /* Spacing the v10 themes published alongside the palette */
+    --content-padding: 1.25rem;
+    --inline-spacing: 0.5rem;
+
+    /* The v9 aliases the v10 themes still carried */
+    --surface-a: var(--surface-card);
+    --surface-b: var(--surface-ground);
+    --surface-c: var(--surface-hover);
+    --surface-d: var(--surface-border);
+    --surface-e: var(--surface-overlay);
+    --surface-f: var(--surface-card);
+
+    /* Surface scale — inverted in the dark scheme, as the v10 dark themes had it */
+    --surface-0: light-dark(#ffffff, #111827);
+    --surface-50: light-dark(#f9fafb, #1f2937);
+    --surface-100: light-dark(#f3f4f6, #374151);
+    --surface-200: light-dark(#e5e7eb, #4b5563);
+    --surface-300: light-dark(#d1d5db, #6b7280);
+    --surface-400: #9ca3af;
+    --surface-500: light-dark(#6b7280, #d1d5db);
+    --surface-600: light-dark(#4b5563, #e5e7eb);
+    --surface-700: light-dark(#374151, #f3f4f6);
+    --surface-800: light-dark(#1f2937, #f9fafb);
+    --surface-900: light-dark(#111827, #ffffff);
+
+    /* Primary scale */
+    --primary-50: light-dark(#f5f9ff, #f7fbff);
+    --primary-100: light-dark(#d0e1fd, #d9e9fe);
+    --primary-200: light-dark(#abc9fb, #bbd8fd);
+    --primary-300: light-dark(#85b2f9, #9cc7fc);
+    --primary-400: light-dark(#609af8, #7eb6fb);
+    --primary-500: light-dark(#3b82f6, #60a5fa);
+    --primary-600: light-dark(#326fd1, #528cd5);
+    --primary-700: light-dark(#295bac, #4374af);
+    --primary-800: light-dark(#204887, #355b8a);
+    --primary-900: light-dark(#183462, #264264);
+
+    /* Gray scale */
+    --gray-50: #f9fafb;
+    --gray-100: #f3f4f6;
+    --gray-200: #e5e7eb;
+    --gray-300: #d1d5db;
+    --gray-400: #9ca3af;
+    --gray-500: #6b7280;
+    --gray-600: #4b5563;
+    --gray-700: #374151;
+    --gray-800: #1f2937;
+    --gray-900: #111827;
+
+    /* Blue scale */
+    --blue-50: #f5f9ff;
+    --blue-100: #d0e1fd;
+    --blue-200: #abc9fb;
+    --blue-300: #85b2f9;
+    --blue-400: #609af8;
+    --blue-500: #3b82f6;
+    --blue-600: #326fd1;
+    --blue-700: #295bac;
+    --blue-800: #204887;
+    --blue-900: #183462;
+
+    /* Green scale */
+    --green-50: #f4fcf7;
+    --green-100: #caf1d8;
+    --green-200: #a0e6ba;
+    --green-300: #76db9b;
+    --green-400: #4cd07d;
+    --green-500: #22c55e;
+    --green-600: #1da750;
+    --green-700: #188a42;
+    --green-800: #136c34;
+    --green-900: #0e4f26;
+
+    /* Yellow scale */
+    --yellow-50: #fefbf3;
+    --yellow-100: #faedc4;
+    --yellow-200: #f6de95;
+    --yellow-300: #f2d066;
+    --yellow-400: #eec137;
+    --yellow-500: #eab308;
+    --yellow-600: #c79807;
+    --yellow-700: #a47d06;
+    --yellow-800: #816204;
+    --yellow-900: #5e4803;
+
+    /* Cyan scale */
+    --cyan-50: #f3fbfd;
+    --cyan-100: #c3edf5;
+    --cyan-200: #94e0ed;
+    --cyan-300: #65d2e4;
+    --cyan-400: #35c4dc;
+    --cyan-500: #06b6d4;
+    --cyan-600: #059bb4;
+    --cyan-700: #047f94;
+    --cyan-800: #036475;
+    --cyan-900: #024955;
+
+    /* Pink scale */
+    --pink-50: #fef6fa;
+    --pink-100: #fad3e7;
+    --pink-200: #f7b0d3;
+    --pink-300: #f38ec0;
+    --pink-400: #f06bac;
+    --pink-500: #ec4899;
+    --pink-600: #c93d82;
+    --pink-700: #a5326b;
+    --pink-800: #822854;
+    --pink-900: #5e1d3d;
+
+    /* Indigo scale */
+    --indigo-50: #f7f7fe;
+    --indigo-100: #dadafc;
+    --indigo-200: #bcbdf9;
+    --indigo-300: #9ea0f6;
+    --indigo-400: #8183f4;
+    --indigo-500: #6366f1;
+    --indigo-600: #5457cd;
+    --indigo-700: #4547a9;
+    --indigo-800: #363885;
+    --indigo-900: #282960;
+
+    /* Teal scale */
+    --teal-50: #f3fbfb;
+    --teal-100: #c7eeea;
+    --teal-200: #9ae0d9;
+    --teal-300: #6dd3c8;
+    --teal-400: #41c5b7;
+    --teal-500: #14b8a6;
+    --teal-600: #119c8d;
+    --teal-700: #0e8174;
+    --teal-800: #0b655b;
+    --teal-900: #084a42;
+
+    /* Orange scale */
+    --orange-50: #fff8f3;
+    --orange-100: #feddc7;
+    --orange-200: #fcc39b;
+    --orange-300: #fba86f;
+    --orange-400: #fa8e42;
+    --orange-500: #f97316;
+    --orange-600: #d46213;
+    --orange-700: #ae510f;
+    --orange-800: #893f0c;
+    --orange-900: #642e09;
+
+    /* Blue-gray scale */
+    --bluegray-50: #f7f8f9;
+    --bluegray-100: #dadee3;
+    --bluegray-200: #bcc3cd;
+    --bluegray-300: #9fa9b7;
+    --bluegray-400: #818ea1;
+    --bluegray-500: #64748b;
+    --bluegray-600: #556376;
+    --bluegray-700: #465161;
+    --bluegray-800: #37404c;
+    --bluegray-900: #282e38;
+
+    /* Purple scale */
+    --purple-50: #fbf7ff;
+    --purple-100: #ead6fd;
+    --purple-200: #dab6fc;
+    --purple-300: #c996fa;
+    --purple-400: #b975f9;
+    --purple-500: #a855f7;
+    --purple-600: #8f48d2;
+    --purple-700: #763cad;
+    --purple-800: #5c2f88;
+    --purple-900: #432263;
+
+    /* Red scale */
+    --red-50: #fff5f5;
+    --red-100: #ffd0ce;
+    --red-200: #ffaca7;
+    --red-300: #ff8780;
+    --red-400: #ff6259;
+    --red-500: #ff3d32;
+    --red-600: #d9342b;
+    --red-700: #b32b23;
+    --red-800: #8c221c;
+    --red-900: #661814;
+}

--- a/Source/scripts/copy-css.sh
+++ b/Source/scripts/copy-css.sh
@@ -2,7 +2,7 @@
 # Copyright (c) Cratis. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-# Ships the two standalone stylesheet layers that have their own package export.
+# Ships the standalone stylesheet layers that have their own package export.
 #
 # Component CSS is NOT copied here any more. It is concatenated into dist/esm/styles.css by the
 # `bundle-styles` Rollup plugin, because a `.css` file sitting in the JavaScript module graph is
@@ -13,7 +13,7 @@ set -euo pipefail
 
 mkdir -p dist/esm
 
-for stylesheet in tokens.css theme.css; do
+for stylesheet in tokens.css theme.css primereact-v10-palette.css; do
     cp "$stylesheet" "dist/esm/$stylesheet"
     echo "Copied $stylesheet"
 done

--- a/Source/theme.css
+++ b/Source/theme.css
@@ -39,8 +39,8 @@
     --cratis-orange-500:         var(--p-orange-500, #f59e0b);
     --cratis-red-500:            var(--p-red-500, #ef4444);
 
-    --cratis-surface-0:          var(--p-surface-0, #ffffff);
-    --cratis-surface-100:        var(--p-surface-100, #f1f5f9);
+    --cratis-surface-0:          var(--p-form-field-background, #ffffff);
+    --cratis-surface-100:        var(--p-content-hover-background, #f1f5f9);
     --cratis-surface-section:    var(--p-surface-50, #f8fafc);
     --cratis-surface-card:       var(--p-surface-0, #ffffff);
     --cratis-surface-overlay:    var(--p-surface-0, #ffffff);
@@ -239,9 +239,35 @@
 .cratis-theme [data-scope='slider'][data-part='handle'] { width: 1.1rem; height: 1.1rem; background: var(--cratis-primary-color); border-radius: 50%; }
 
 /* ── Dialog ──────────────────────────────────────────────────────────────── */
+/* PrimeReact 11 renders the backdrop and the positioner as siblings under the portal,
+   and leaves placing them to CSS: without these two rules the backdrop is a zero-height
+   block and the popup flows in after the page content, below the fold. The layout is
+   the one PrimeReact's own dialog style applies (`@primereact/styles/dialog`). */
 .cratis-theme [data-scope='dialog'][data-part='backdrop'],
-.cratis-theme [data-scope='dialog'][data-part='mask'] { background: var(--cratis-maskbg, rgba(0, 0, 0, 0.5)); }
+.cratis-theme [data-scope='dialog'][data-part='mask'] {
+    position: fixed;
+    inset: 0;
+    background: var(--cratis-maskbg, rgba(0, 0, 0, 0.5));
+}
+.cratis-theme [data-scope='dialog'][data-part='positioner'] {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem;
+    pointer-events: none;
+}
+.cratis-theme [data-scope='dialog'][data-part='positioner'][data-modal] { pointer-events: auto; }
+.cratis-theme [data-scope='dialog'][data-part='positioner'][data-position='top'] { align-items: flex-start; }
+.cratis-theme [data-scope='dialog'][data-part='positioner'][data-position='bottom'] { align-items: flex-end; }
+.cratis-theme [data-scope='dialog'][data-part='positioner'][data-position='left'] { justify-content: flex-start; }
+.cratis-theme [data-scope='dialog'][data-part='positioner'][data-position='right'] { justify-content: flex-end; }
 .cratis-theme [data-scope='dialog'][data-part='popup'] {
+    display: flex;
+    flex-direction: column;
+    max-height: 100%;
+    pointer-events: auto;
     background: var(--cratis-surface-overlay);
     color: var(--cratis-text-color);
     border-radius: 0.75rem;
@@ -257,7 +283,7 @@
     border-bottom: 1px solid var(--cratis-surface-border);
     font-weight: 600;
 }
-.cratis-theme [data-scope='dialog'][data-part='content'] { padding: 1.25rem; }
+.cratis-theme [data-scope='dialog'][data-part='content'] { padding: 1.25rem; overflow-y: auto; }
 .cratis-theme [data-scope='dialog'][data-part='footer'] { padding: 1rem 1.25rem; border-top: 1px solid var(--cratis-surface-border); }
 .cratis-theme [data-scope='dialog'][data-part='close'] {
     border: none; background: transparent; color: var(--cratis-text-color-secondary);

--- a/Source/tokens.css
+++ b/Source/tokens.css
@@ -24,10 +24,12 @@
  * v11 ships ZERO CSS. There is no `primereact/resources/themes/*.css` to import any
  * more. The --p-* custom properties are emitted **at runtime** by @primeuix/styled
  * when a preset (a plain JS token object from @primeuix/themes — Aura, Lara, Nora)
- * is handed to the provider:
+ * is handed to the provider - which `styledMode()` from `@cratis/components/styled`
+ * does, together with PrimeReact's own component styles for every primitive (a
+ * preset alone leaves the primitives without their `p-*` classes):
  *
- *   import Aura from '@primeuix/themes/aura';
- *   <CratisComponentsProvider value={{ theme: { preset: Aura } }}>
+ *   import { styledMode } from '@cratis/components/styled';
+ *   <CratisComponentsProvider value={{ license, ...styledMode() }}>
  *
  * So the chain is: preset (JS) → --p-* (runtime) → --cratis-* (this file) → component CSS.
  *
@@ -39,12 +41,12 @@
  *
  * ## Three ways to get a look
  *
- * 1. **A licensed preset** — `value={{ theme: { preset: Aura } }}`. The styled layer
- *    is license-gated in v11; without a PrimeUI key it nags and falls back.
- * 2. **The Cratis baseline theme** — `import '@cratis/components/theme'`. A
- *    license-free stylesheet that assigns the --cratis-* tokens directly (light and
- *    dark), so it needs no preset and no key. It defers to a preset's --p-* values
- *    when one is present.
+ * 1. **Styled mode** — `value={{ license, ...styledMode() }}` from
+ *    `@cratis/components/styled`: a preset plus PrimeReact's component styles.
+ * 2. **The Cratis baseline theme** — `import '@cratis/components/theme'`. A stylesheet
+ *    that assigns the --cratis-* tokens directly (light and dark), so it needs no preset
+ *    and no @primeuix/themes install. It defers to a preset's --p-* values when one is
+ *    present.
  * 3. **Your own tokens** — override any --cratis-* on :root (or any ancestor):
  *
  *   :root {
@@ -60,8 +62,13 @@
 
 :root {
     /* Surfaces */
-    --cratis-surface-0:        var(--p-surface-0, var(--surface-0));
-    --cratis-surface-100:      var(--p-surface-100, var(--surface-100));
+    /* v10's surface scale ran from the page tone (0) up through raised surfaces (100, 200, …)
+     * and inverted in its dark themes, so surface-0 was the darkest tone there. v11's
+     * --p-surface-N is a plain palette that is white at 0 in both schemes, so it cannot stand
+     * in. The two are read here as what they were used for: the tone underneath a form field
+     * and the tone of a raised or hovered surface, which v11 names semantically. */
+    --cratis-surface-0:        var(--p-form-field-background, var(--surface-0));
+    --cratis-surface-100:      var(--p-content-hover-background, var(--surface-100));
     /* v11 has no page-canvas/section token — map to the neutral content surface;
      * separation in v11 comes from borders (content-border-color), not fills. */
     --cratis-surface-ground:   var(--p-content-background, var(--surface-ground));

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -4,12 +4,12 @@
 import typescript from '@rollup/plugin-typescript';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import peerDepsExternal from 'rollup-plugin-peer-deps-external';
-import { readdirSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { dirname, join, relative, resolve } from 'path';
 import { createRequire } from 'module';
 
 /** Stylesheets that are entry points or token layers in their own right, not component rules. */
-const STANDALONE_STYLESHEETS = new Set(['tailwind.css', 'tailwind-utilities.css', 'tokens.css', 'theme.css', 'styles.css']);
+const STANDALONE_STYLESHEETS = new Set(['tailwind.css', 'tailwind-utilities.css', 'tokens.css', 'theme.css', 'primereact-v10-palette.css', 'styles.css']);
 
 /** Directories that never hold shipped component CSS. */
 const NON_SOURCE_DIRECTORIES = new Set(['node_modules', 'dist', 'storybook-static', '.storybook', 'wwwroot']);
@@ -143,10 +143,19 @@ function generatePackageJson(esmPath) {
     };
 }
 
+/**
+ * Entry points that are deliberately NOT reachable from `index.ts`. The root re-exports every
+ * component namespace, so anything imported there lands in every consumer's graph — and the
+ * styled-mode entry pulls in `@primereact/styles` and `@primeuix/themes`, which are optional
+ * peers a consumer that runs unstyled never installs. Listing them here gives them their own
+ * bundle without touching the root.
+ */
+const STANDALONE_ENTRIES = ['Styled/index.ts'];
+
 export function rollup(esmPath, tsconfigPath, pkg) {
     const sourceDir = dirname(tsconfigPath);
     return {
-        input: 'index.ts',
+        input: ['index.ts', ...STANDALONE_ENTRIES.filter((entry) => existsSync(resolve(sourceDir, entry)))],
 
         output: [
             {


### PR DESCRIPTION
# Summary

PrimeReact 11's `primereact` package is unstyled primitives, so a `@primeuix/themes` preset handed to the provider emitted design tokens but styled nothing this library renders — every application that upgraded lost its look. Styled mode brings PrimeReact's own component styles to every primitive under the provider, painted by a preset that reproduces the `lara-blue` look Cratis applications had on PrimeReact 10, and the palette those applications' own CSS is written against comes back as a stylesheet.

## Added

- `@cratis/components/styled` — `styledMode()` configures the provider for PrimeReact 11's styled mode: `primeReactStyles` (PrimeReact's component styles for every primitive, applied through the provider's `defaults`) together with a `@primeuix/themes` preset, emitted into the `primereact` cascade layer so an application's own CSS overrides the theme as it did on PrimeReact 10. `CratisPreset` is Lara on the blue primary and gray surfaces of `lara-light-blue` / `lara-dark-blue`; any preset can be passed instead. `@primereact/styles` and `@primeuix/themes` are optional peers, needed only for this path.
- `@cratis/components/primereact-v10-palette` — the `--surface-*`, `--text-color`, `--primary-color`, `--highlight-*`, `--focus-ring`, `--surface-0…900`, `--primary-*` and color-scale variables PrimeReact 10's themes published, with the `lara-blue` values in both schemes, so CSS written against them keeps resolving.
- `Message` renders the severity glyph PrimeReact 10 showed; an `icon` prop replaces or removes it.

## Changed

- `Dropdown` reads `label` / `value` off option objects when no `optionLabel` / `optionValue` is given, as PrimeReact 10's Dropdown did, and renders the trigger chevron and clear glyph again.
- Table column headers render through PrimeReact's title part, so a theme's column-title weight applies, and the empty-message row is padded and bordered like a data row.
- `--cratis-surface-0` and `--cratis-surface-100` resolve from PrimeReact 11's form-field and hover surface tokens rather than `--p-surface-0/100`, which are white in both color schemes.

## Fixed

- The Cratis baseline theme positions the dialog backdrop and centers the dialog; both rendered in normal flow below the page content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)